### PR TITLE
Allow customization of scrolling elasticity

### DIFF
--- a/Source/SwipeTableViewCell.swift
+++ b/Source/SwipeTableViewCell.swift
@@ -39,7 +39,7 @@ open class SwipeTableViewCell: UITableViewCell {
         return gesture
     }()
     
-    let elasticScrollRatio: CGFloat = 0.4
+    public var elasticScrollRatio: CGFloat = 0.4
     var scrollRatio: CGFloat = 1.0
     
     /// :nodoc:
@@ -155,7 +155,8 @@ open class SwipeTableViewCell: UITableViewCell {
                 } else {
                     target.center.x = gesture.elasticTranslation(in: target,
                                                                  withLimit: CGSize(width: targetOffset, height: 0),
-                                                                 fromOriginalCenter: CGPoint(x: originalCenter, y: 0)).x
+                                                                 fromOriginalCenter: CGPoint(x: originalCenter, y: 0),
+                                                                 applyingRatio: elasticScrollRatio).x
                 }
                 
                 actionsView.setExpanded(expanded: expanded, feedback: true)


### PR DESCRIPTION
It'd be great to be able to customize how elastic the scrolling becomes after reaching the end of the buttons. For example, I'd like to be able to allow the user to keep smoothly pulling the selected area all the way across by setting `elasticScrollRatio = 1.0`.