### PR TITLE
Add spm install guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,15 +111,9 @@ github "SwipeCellKit/SwipeCellKit"
 #### [Swift Package Manager](https://swift.org/package-manager/)
 
 ```swift
-import PackageDescription
-
-let package = Package(
-    name: "YOUR_PROJECT_NAME",
-    products: [],
-    dependencies: [
-        .package(url: "https://github.com/swipecellkit/swipecellkit.git", from: "2.7.1")
-    ]
-)
+dependencies: [
+    .package(url: "git@github.com:SwipeCellKit/SwipeCellKit.git", from: "2.7.1")
+]
 ```
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -108,6 +108,20 @@ pod 'SwipeCellKit', '2.4.3'
 github "SwipeCellKit/SwipeCellKit"
 ````
 
+#### [Swift Package Manager(SPM)](https://swift.org/package-manager/)
+
+```swift
+import PackageDescription
+
+let package = Package(
+    name: "YOUR_PROJECT_NAME",
+    products: [],
+    dependencies: [
+        .package(url: "https://github.com/swipecellkit/swipecellkit.git", from: "2.7.1")
+    ]
+)
+```
+
 ## Documentation
 
 Read the [docs][docsLink]. Generated with [jazzy](https://github.com/realm/jazzy). Hosted by [GitHub Pages](https://pages.github.com).

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ pod 'SwipeCellKit', '2.4.3'
 github "SwipeCellKit/SwipeCellKit"
 ````
 
-#### [Swift Package Manager(SPM)](https://swift.org/package-manager/)
+#### [Swift Package Manager](https://swift.org/package-manager/)
 
 ```swift
 import PackageDescription


### PR DESCRIPTION
# Summary
SwipeCellKit can be installed using Swift Package Manager. However, there is no guideline on how to do it in README.md. This PR adds that guideline.

\* as of Thursday, 3 October 2019