### PR TITLE
Render active actions after layoutSubviews.

### DIFF
--- a/Source/SwipeCollectionViewCell.swift
+++ b/Source/SwipeCollectionViewCell.swift
@@ -205,6 +205,20 @@ open class SwipeCollectionViewCell: UICollectionViewCell {
         }
         isPreviouslySelected = false
     }
+
+    open override func layoutSubviews() {
+        super.layoutSubviews()
+        if state.isActive {
+            switch state {
+            case .left:
+                swipeController.showSwipe(orientation: .left, animated: false)
+            case .right:
+                swipeController.showSwipe(orientation: .right, animated: false)
+            case .animatingToCenter, .center, .dragging:
+                break
+            }
+        }
+    }
 }
 
 extension SwipeCollectionViewCell: SwipeControllerDelegate {

--- a/Source/SwipeTableViewCell.swift
+++ b/Source/SwipeTableViewCell.swift
@@ -177,6 +177,20 @@ open class SwipeTableViewCell: UITableViewCell {
         }
         isPreviouslySelected = false
     }
+
+    open override func layoutSubviews() {
+        super.layoutSubviews()
+        if state.isActive {
+            switch state {
+            case .left:
+                swipeController.showSwipe(orientation: .left, animated: false)
+            case .right:
+                swipeController.showSwipe(orientation: .right, animated: false)
+            case .animatingToCenter, .center, .dragging:
+                break
+            }
+        }
+    }
 }
 
 extension SwipeTableViewCell: SwipeControllerDelegate {


### PR DESCRIPTION
This resolves a bug where if something triggers a layoutSubviews in your {Collection,Table}ViewCell while the actions are visible, the actions will remain visible.

Without this fix the actions would disappear despite having an active state.