### PR TITLE
Navigation controller interactive pop gesture not working

### DIFF
--- a/Source/SwipeController.swift
+++ b/Source/SwipeController.swift
@@ -367,6 +367,15 @@ extension SwipeController: UIGestureRecognizerDelegate {
         
         return true
     }
+    
+    func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldRequireFailureOf otherGestureRecognizer: UIGestureRecognizer) -> Bool {
+        if let topmost = UIApplication.topmostViewController() as? UINavigationController {
+            if gestureRecognizer == self.panGestureRecognizer && otherGestureRecognizer == topmost.interactivePopGestureRecognizer {
+                return true
+            }
+        }
+        return false
+    }
 }
 
 extension SwipeController: SwipeActionsViewDelegate {

--- a/Source/UIApplication+Ext.swift
+++ b/Source/UIApplication+Ext.swift
@@ -1,0 +1,14 @@
+//
+//  UIApplication+Ext.swift
+//  SwipeCellKit
+//
+//  Created by Văn Tiến Tú on 4/19/20.
+//
+
+import UIKit
+
+extension UIApplication {
+    static func topmostViewController()  -> UIViewController? {
+        return UIApplication.shared.keyWindow?.rootViewController
+    }
+}

--- a/SwipeCellKit.xcodeproj/project.pbxproj
+++ b/SwipeCellKit.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		B93ECA951EDEE8A700AE05AD /* SwipeCollectionViewCellDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B93ECA941EDEE8A700AE05AD /* SwipeCollectionViewCellDelegate.swift */; };
 		B93ECA991EDEE93D00AE05AD /* SwipeAccessibilityCustomAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = B93ECA981EDEE93D00AE05AD /* SwipeAccessibilityCustomAction.swift */; };
 		B93ECA9B1EDEEABA00AE05AD /* SwipeOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B93ECA9A1EDEEABA00AE05AD /* SwipeOptions.swift */; };
+		EF934E6C244C669F0060A446 /* UIApplication+Ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF934E6B244C669F0060A446 /* UIApplication+Ext.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -58,6 +59,7 @@
 		B93ECA941EDEE8A700AE05AD /* SwipeCollectionViewCellDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwipeCollectionViewCellDelegate.swift; sourceTree = "<group>"; };
 		B93ECA981EDEE93D00AE05AD /* SwipeAccessibilityCustomAction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwipeAccessibilityCustomAction.swift; sourceTree = "<group>"; };
 		B93ECA9A1EDEEABA00AE05AD /* SwipeOptions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwipeOptions.swift; sourceTree = "<group>"; };
+		EF934E6B244C669F0060A446 /* UIApplication+Ext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIApplication+Ext.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -112,6 +114,7 @@
 				3FD016DE1E6D778700B54FFC /* SwipeExpanding.swift */,
 				3F19AD031E8D711C006B4B3A /* SwipeFeedback.swift */,
 				3F234AD51E44A94F00E22A38 /* Extensions.swift */,
+				EF934E6B244C669F0060A446 /* UIApplication+Ext.swift */,
 				3F234AD01E44A8F200E22A38 /* Supporting Files */,
 			);
 			path = Source;
@@ -206,6 +209,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				EF934E6C244C669F0060A446 /* UIApplication+Ext.swift in Sources */,
 				3F234AD81E44A94F00E22A38 /* SwipeActionsView.swift in Sources */,
 				3F234AD71E44A94F00E22A38 /* SwipeAction.swift in Sources */,
 				3F3ED7101E486993009DD5D8 /* SwipeActionButton.swift in Sources */,


### PR DESCRIPTION
- I was faced with a problem.
- I used navigation controller push  to  other view controller and  enable interactivePopGestureRecognizer.
- I have customized  back button when  I  swipe back to pop view controller but interactive pop gesture can not recognized. So I found the solution  to resolve that  problem.
- Please review my solution.