### PR TITLE
Add auto-shrink behavior

### DIFF
--- a/Source/SwipeController.swift
+++ b/Source/SwipeController.swift
@@ -324,6 +324,10 @@ class SwipeController: NSObject {
     func targetCenter(active: Bool) -> CGFloat {
         guard let swipeable = self.swipeable else { return 0 }
         guard let actionsView = swipeable.actionsView, active == true else { return swipeable.bounds.midX }
+
+        if actionsView.options.autoShrink {
+            return swipeable.bounds.midX
+        }
         
         return swipeable.bounds.midX - actionsView.preferredWidth * actionsView.orientation.scale
     }

--- a/Source/SwipeOptions.swift
+++ b/Source/SwipeOptions.swift
@@ -17,6 +17,9 @@ public struct SwipeOptions {
     
     /// The expansion style. Expansion is the behavior when the cell is swiped past a defined threshold.
     public var expansionStyle: SwipeExpansionStyle?
+
+    /// If set true, whenever user let go, the actionsView will shrink to 0 width
+    public var autoShrink: Bool = false
     
     /// The object that is notified when expansion changes.
     ///


### PR DESCRIPTION
We are using SwipeCellKit to have one swipe action and trigger the action by dragging pass threshold. The actionsView should auto-shrink if user let go instead of expanding to preferredWidth for the action button. We can define the action's transitionDelegate to achieve threshold as action trigger but not able to achieve the auto-shrink behavior. Thus creating this pull request to adding an auto-shrink attribute in SwipeOptions to achieve this.