### PR TITLE
Add shouldDelete*At methods to swipe cell delegates, invoke on swipe animation completion

### DIFF
--- a/Source/SwipeCollectionViewCell.swift
+++ b/Source/SwipeCollectionViewCell.swift
@@ -194,6 +194,7 @@ open class SwipeCollectionViewCell: UICollectionViewCell {
     func reset() {
         contentView.clipsToBounds = false
         swipeController.reset()
+        swipeController.resetSwipe()
         collectionView?.setGestureEnabled(true)
     }
     

--- a/Source/SwipeCollectionViewCell.swift
+++ b/Source/SwipeCollectionViewCell.swift
@@ -250,7 +250,9 @@ extension SwipeCollectionViewCell: SwipeControllerDelegate {
     }
     
     func swipeController(_ controller: SwipeController, didDeleteSwipeableAt indexPath: IndexPath) {
-        collectionView?.deleteItems(at: [indexPath])
+        guard let collectionView = collectionView, let indexPath = collectionView.indexPath(for: self) else { return }
+
+        delegate?.collectionView(collectionView, shouldDeleteItemAt: indexPath)
     }
 }
 

--- a/Source/SwipeCollectionViewCellDelegate.swift
+++ b/Source/SwipeCollectionViewCellDelegate.swift
@@ -60,6 +60,15 @@ public protocol SwipeCollectionViewCellDelegate: class {
      - parameter orientation: The side of the item.
      */
     func collectionView(_ collectionView: UICollectionView, didEndEditingItemAt indexPath: IndexPath?, for orientation: SwipeActionsOrientation)
+
+    /**
+     Tells the delegate that the collection view should delete an item following a swipe action.
+
+     - parameter collectionView: The collection view object providing this information.
+
+     - parameter indexPath: The index path of the item.
+     */
+    func collectionView(_ collectionView: UICollectionView, shouldDeleteItemAt indexPath: IndexPath)
     
     /**
      Asks the delegate for visibile rectangle of the collection view, which is used to ensure swipe actions are vertically centered within the visible portion of the item.
@@ -84,6 +93,10 @@ public extension SwipeCollectionViewCellDelegate {
     func collectionView(_ collectionView: UICollectionView, willBeginEditingItemAt indexPath: IndexPath, for orientation: SwipeActionsOrientation) {}
     
     func collectionView(_ collectionView: UICollectionView, didEndEditingItemAt indexPath: IndexPath?, for orientation: SwipeActionsOrientation) {}
+
+    func collectionView(_ collectionView: UICollectionView, shouldDeleteItemAt indexPath: IndexPath) {
+        collectionView.deleteItems(at: [indexPath])
+    }
     
     func visibleRect(for collectionView: UICollectionView) -> CGRect? {
         return nil

--- a/Source/SwipeController.swift
+++ b/Source/SwipeController.swift
@@ -338,6 +338,8 @@ class SwipeController: NSObject {
         
         swipeable?.actionsView?.removeFromSuperview()
         swipeable?.actionsView = nil
+
+        actionsContainerView?.mask = nil
     }
     
 }
@@ -418,8 +420,6 @@ extension SwipeController: SwipeActionsViewDelegate {
             case .delete:
                 actionsContainerView.mask = actionsView.createDeletionMask()
                 
-                self.delegate?.swipeController(self, didDeleteSwipeableAt: indexPath)
-                
                 UIView.animate(withDuration: 0.3, animations: {
                     guard let actionsContainerView = self.actionsContainerView else { return }
                     
@@ -431,9 +431,9 @@ extension SwipeController: SwipeActionsViewDelegate {
                         actionsView.alpha = 0
                     }
                 }) { [weak self] _ in
-                    self?.actionsContainerView?.mask = nil
-                    self?.resetSwipe()
-                    self?.reset()
+                    guard let `self` = self else { return }
+
+                    self.delegate?.swipeController(self, didDeleteSwipeableAt: indexPath)
                 }
             case .reset:
                 self.hideSwipe(animated: true)

--- a/Source/SwipeTableViewCell.swift
+++ b/Source/SwipeTableViewCell.swift
@@ -166,6 +166,7 @@ open class SwipeTableViewCell: UITableViewCell {
     
     func reset() {
         swipeController.reset()
+        swipeController.resetSwipe()
         clipsToBounds = false
     }
     

--- a/Source/SwipeTableViewCell.swift
+++ b/Source/SwipeTableViewCell.swift
@@ -222,6 +222,8 @@ extension SwipeTableViewCell: SwipeControllerDelegate {
     }
     
     func swipeController(_ controller: SwipeController, didDeleteSwipeableAt indexPath: IndexPath) {
-        tableView?.deleteRows(at: [indexPath], with: .none)
+        guard let tableView = tableView, let indexPath = tableView.indexPath(for: self) else { return }
+
+        delegate?.tableView(tableView, shouldDeleteRowAt: indexPath)
     }
 }

--- a/Source/SwipeTableViewCellDelegate.swift
+++ b/Source/SwipeTableViewCellDelegate.swift
@@ -61,6 +61,16 @@ public protocol SwipeTableViewCellDelegate: class {
      - parameter orientation: The side of the cell.
      */
     func tableView(_ tableView: UITableView, didEndEditingRowAt indexPath: IndexPath?, for orientation: SwipeActionsOrientation)
+
+
+    /**
+     Tells the delegate that the table view should delete a row following a swipe action.
+
+     - parameter tableView: The table view object providing this information.
+
+     - parameter indexPath: The index path of the row.
+     */
+    func tableView(_ tableView: UITableView, shouldDeleteRowAt indexPath: IndexPath)
     
     /**
      Asks the delegate for visibile rectangle of the table view, which is used to ensure swipe actions are vertically centered within the visible portion of the cell.
@@ -85,6 +95,10 @@ public extension SwipeTableViewCellDelegate {
     func tableView(_ tableView: UITableView, willBeginEditingRowAt indexPath: IndexPath, for orientation: SwipeActionsOrientation) {}
     
     func tableView(_ tableView: UITableView, didEndEditingRowAt indexPath: IndexPath?, for orientation: SwipeActionsOrientation) {}
+
+    func tableView(_ tableView: UITableView, shouldDeleteRowAt indexPath: IndexPath) {
+        tableView.deleteRows(at: [indexPath], with: .none)
+    }
     
     func visibleRect(for tableView: UITableView) -> CGRect? {
         return nil


### PR DESCRIPTION
Currently both `SwipeCollectionViewCell` and `SwipeTableViewCell` automatically delete the cells on `swipeController(:didDeleteSwipeableAt:)` and don't allow any customization, like what's allowed in other similar methods.

While on most scenarios the default behavior is desired, there are some scenarios where users might want to control how the deletion is effectively made on the container (CollectionView or TableView). Some examples are:
- Data-driven setups that use diffing
- Customize the deletion animation (table view)

To achieve that, a new delegate method was added to both the `SwipeCollectionViewCellDelegate` and `SwipeTableViewCellDelegate` to allow customizing the deletion on the container, having the current implementations as the default in protocol extensions.

Following the above changes to the cell deletion flow on swipe completion, the actual cell deletion trigger was moved to the animation completion so that we wait for the swipe animation to complete before actually triggering the cell removal.

To prevent visual artifacts, the reset calls in the animation completion were moved to the `prepareForReuse` of each cell, achieving the same result.

## Changes

- Add new `collectionView(:shouldDeleteItemAt:)` delegate method to `SwipeCollectionViewCellDelegate`, and invoke it on `SwipeCollectionViewCell.swipeController(:didDeleteSwipeableAt:)`.

- Add new `tableView(:shouldDeleteRowAt:)` delegate method to `SwipeTableViewCellDelegate` and invoke it on `SwipeTableViewCell.swipeController(:didDeleteSwipeableAt:)`.

- Invoke `swipeController(:didDeleteSwipeableAt:)` delegate call on delete animation completion

- Remove reset logic from `SwipeController`'s delete animation completion closure, moving it to cell's `prepareForReuse`.