### PR TITLE
[Update] : `class` to `Anyobject`

### DIFF
--- a/Source/SwipeActionsView.swift
+++ b/Source/SwipeActionsView.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-protocol SwipeActionsViewDelegate: class {
+protocol SwipeActionsViewDelegate: AnyObject {
     func swipeActionsView(_ swipeActionsView: SwipeActionsView, didSelect action: SwipeAction)
 }
 

--- a/Source/SwipeCollectionViewCellDelegate.swift
+++ b/Source/SwipeCollectionViewCellDelegate.swift
@@ -10,7 +10,7 @@ import UIKit
 /**
  The `SwipeCollectionViewCellDelegate` protocol is adopted by an object that manages the display of action buttons when the item is swiped.
  */
-public protocol SwipeCollectionViewCellDelegate: class {
+public protocol SwipeCollectionViewCellDelegate: AnyObject {
     /**
      Asks the delegate for the actions to display in response to a swipe in the specified item.
      

--- a/Source/SwipeController.swift
+++ b/Source/SwipeController.swift
@@ -8,7 +8,7 @@
 import Foundation
 import UIKit
 
-protocol SwipeControllerDelegate: class {
+protocol SwipeControllerDelegate: AnyObject {
     
     func swipeController(_ controller: SwipeController, canBeginEditingSwipeableFor orientation: SwipeActionsOrientation) -> Bool
     


### PR DESCRIPTION
Xcode 12.5 - Using 'class' keyword for protocol inheritance is deprecated, it was changed to use 'AnyObject' instead 