### PR TITLE
Add initial visionOS support

### DIFF
--- a/Source/SwipeActionsView.swift
+++ b/Source/SwipeActionsView.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-protocol SwipeActionsViewDelegate: class {
+protocol SwipeActionsViewDelegate: AnyObject {
     func swipeActionsView(_ swipeActionsView: SwipeActionsView, didSelect action: SwipeAction)
 }
 
@@ -16,9 +16,11 @@ class SwipeActionsView: UIView {
     
     let transitionLayout: SwipeTransitionLayout
     var layoutContext: ActionsViewLayoutContext
-    
+
+    #if !os(visionOS)
     var feedbackGenerator: SwipeFeedback
-    
+    #endif
+
     var expansionAnimator: SwipeAnimator?
     
     var expansionDelegate: SwipeExpanding? {
@@ -104,9 +106,11 @@ class SwipeActionsView: UIView {
         
         self.layoutContext = ActionsViewLayoutContext(numberOfActions: actions.count, orientation: orientation)
         
+        #if !os(visionOS)
         feedbackGenerator = SwipeFeedback(style: .light)
         feedbackGenerator.prepare()
-        
+        #endif
+
         super.init(frame: .zero)
         
         clipsToBounds = true
@@ -211,11 +215,13 @@ class SwipeActionsView: UIView {
         
         self.expanded = expanded
         
+        #if !os(visionOS)
         if feedback {
             feedbackGenerator.impactOccurred()
             feedbackGenerator.prepare()
         }
-        
+        #endif
+
         let timingParameters = expansionDelegate?.animationTimingParameters(buttons: buttons.reversed(), expanding: expanded)
         
         if expansionAnimator?.isRunning == true {

--- a/Source/SwipeCollectionViewCellDelegate.swift
+++ b/Source/SwipeCollectionViewCellDelegate.swift
@@ -10,7 +10,7 @@ import UIKit
 /**
  The `SwipeCollectionViewCellDelegate` protocol is adopted by an object that manages the display of action buttons when the item is swiped.
  */
-public protocol SwipeCollectionViewCellDelegate: class {
+public protocol SwipeCollectionViewCellDelegate: AnyObject {
     /**
      Asks the delegate for the actions to display in response to a swipe in the specified item.
      

--- a/Source/SwipeController.swift
+++ b/Source/SwipeController.swift
@@ -8,7 +8,7 @@
 import Foundation
 import UIKit
 
-protocol SwipeControllerDelegate: class {
+protocol SwipeControllerDelegate: AnyObject {
     
     func swipeController(_ controller: SwipeController, canBeginEditingSwipeableFor orientation: SwipeActionsOrientation) -> Bool
     

--- a/Source/SwipeFeedback.swift
+++ b/Source/SwipeFeedback.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 
+@available(visionOS, unavailable)
 final class SwipeFeedback {
     enum Style {
         case light

--- a/Source/SwipeTableViewCellDelegate.swift
+++ b/Source/SwipeTableViewCellDelegate.swift
@@ -10,8 +10,8 @@ import UIKit
 /**
  The `SwipeTableViewCellDelegate` protocol is adopted by an object that manages the display of action buttons when the cell is swiped.
  */
-public protocol SwipeTableViewCellDelegate: class {
-    
+public protocol SwipeTableViewCellDelegate: AnyObject {
+
     /**
      Asks the delegate for the actions to display in response to a swipe in the specified row.
      


### PR DESCRIPTION
### Background
The `UIImpactFeedbackGenerator` is not available in `visionOS`.

### What has been done?
1. Made `SwipeFeedback` not available for `visionOS`.
2. Covered with `#if !os(visionOS)` the places that are using the feedback.
3. Fixed the build warnings related to `class -> AnyObject`.