### PR TITLE
New api capabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 `SwipeCellKit` adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+#### Added
+
+- Custom transition preparation and interactive transition context state.
+- Configurable release activation thresholds.
+- Equal and individual action-width modes.
+- Fill-available-space expansion layout and expansion-width callbacks for custom action content.
+
+#### Changed
+
+- Transition layouts and expansion calculations now support actions with different widths.
+
+---
+
 ## [2.7.1](https://github.com/jerkoch/SwipeCellKit/releases/tag/2.7.1)
 
 #### Added

--- a/Example/MailExample.xcodeproj/project.pbxproj
+++ b/Example/MailExample.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		290FF0C72823EBC200212EAE /* RoundedCornersActionContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 290FF0C62823EBC200212EAE /* RoundedCornersActionContentView.swift */; };
 		290FF0C92823EC6000212EAE /* UIColor+Highlighted.swift in Sources */ = {isa = PBXBuildFile; fileRef = 290FF0C82823EC6000212EAE /* UIColor+Highlighted.swift */; };
 		291D91482835380B00FCA894 /* MailExampleUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 291D91472835380B00FCA894 /* MailExampleUITests.swift */; };
+		296D458C28A3DA2B0002C5B5 /* ListPagesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 296D458B28A3DA2B0002C5B5 /* ListPagesViewController.swift */; };
 		29FC1CF62822AD2A00F48AA8 /* CustomMailCollectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29FC1CF52822AD2A00F48AA8 /* CustomMailCollectionViewController.swift */; };
 		3F234B0A1E44AC2600E22A38 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F234B041E44AC2600E22A38 /* AppDelegate.swift */; };
 		3F234B0B1E44AC2600E22A38 /* MailTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F234B051E44AC2600E22A38 /* MailTableViewController.swift */; };
@@ -54,6 +55,7 @@
 		290FF0C82823EC6000212EAE /* UIColor+Highlighted.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+Highlighted.swift"; sourceTree = "<group>"; };
 		291D91452835380B00FCA894 /* MailExampleUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MailExampleUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		291D91472835380B00FCA894 /* MailExampleUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MailExampleUITests.swift; sourceTree = "<group>"; };
+		296D458B28A3DA2B0002C5B5 /* ListPagesViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListPagesViewController.swift; sourceTree = "<group>"; };
 		29FC1CF52822AD2A00F48AA8 /* CustomMailCollectionViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomMailCollectionViewController.swift; sourceTree = "<group>"; };
 		3F234AE31E44AA5E00E22A38 /* MailExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = MailExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		3F234AF21E44AA5E00E22A38 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -137,6 +139,7 @@
 				3F234B051E44AC2600E22A38 /* MailTableViewController.swift */,
 				B93ECA9C1EDEF1EA00AE05AD /* MailCollectionViewController.swift */,
 				29FC1CF52822AD2A00F48AA8 /* CustomMailCollectionViewController.swift */,
+				296D458B28A3DA2B0002C5B5 /* ListPagesViewController.swift */,
 				290FF0C62823EBC200212EAE /* RoundedCornersActionContentView.swift */,
 				290FF0C82823EC6000212EAE /* UIColor+Highlighted.swift */,
 				B93ECA9E1EDEF56300AE05AD /* Shared.swift */,
@@ -276,6 +279,7 @@
 				290FF0C72823EBC200212EAE /* RoundedCornersActionContentView.swift in Sources */,
 				29FC1CF62822AD2A00F48AA8 /* CustomMailCollectionViewController.swift in Sources */,
 				B93ECA9F1EDEF56300AE05AD /* Shared.swift in Sources */,
+				296D458C28A3DA2B0002C5B5 /* ListPagesViewController.swift in Sources */,
 				3F234B0A1E44AC2600E22A38 /* AppDelegate.swift in Sources */,
 				3F234B0C1E44AC2600E22A38 /* Data.swift in Sources */,
 				290FF0C92823EC6000212EAE /* UIColor+Highlighted.swift in Sources */,

--- a/Example/MailExample.xcodeproj/project.pbxproj
+++ b/Example/MailExample.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		290FF0C22823EB0300212EAE /* SwipeCellKit.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 290FF0C02823EB0300212EAE /* SwipeCellKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		290FF0C72823EBC200212EAE /* RoundedCornersActionContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 290FF0C62823EBC200212EAE /* RoundedCornersActionContentView.swift */; };
 		290FF0C92823EC6000212EAE /* UIColor+Highlighted.swift in Sources */ = {isa = PBXBuildFile; fileRef = 290FF0C82823EC6000212EAE /* UIColor+Highlighted.swift */; };
+		291D91482835380B00FCA894 /* MailExampleUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 291D91472835380B00FCA894 /* MailExampleUITests.swift */; };
 		29FC1CF62822AD2A00F48AA8 /* CustomMailCollectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29FC1CF52822AD2A00F48AA8 /* CustomMailCollectionViewController.swift */; };
 		3F234B0A1E44AC2600E22A38 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F234B041E44AC2600E22A38 /* AppDelegate.swift */; };
 		3F234B0B1E44AC2600E22A38 /* MailTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F234B051E44AC2600E22A38 /* MailTableViewController.swift */; };
@@ -21,6 +22,16 @@
 		B93ECA9D1EDEF1EA00AE05AD /* MailCollectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B93ECA9C1EDEF1EA00AE05AD /* MailCollectionViewController.swift */; };
 		B93ECA9F1EDEF56300AE05AD /* Shared.swift in Sources */ = {isa = PBXBuildFile; fileRef = B93ECA9E1EDEF56300AE05AD /* Shared.swift */; };
 /* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		291D914B2835380B00FCA894 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 3F234ADB1E44AA5E00E22A38 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 3F234AE21E44AA5E00E22A38;
+			remoteInfo = MailExample;
+		};
+/* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
 		290FF0C32823EB0300212EAE /* Embed Frameworks */ = {
@@ -41,6 +52,8 @@
 		290FF0C02823EB0300212EAE /* SwipeCellKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = SwipeCellKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		290FF0C62823EBC200212EAE /* RoundedCornersActionContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoundedCornersActionContentView.swift; sourceTree = "<group>"; };
 		290FF0C82823EC6000212EAE /* UIColor+Highlighted.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+Highlighted.swift"; sourceTree = "<group>"; };
+		291D91452835380B00FCA894 /* MailExampleUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MailExampleUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		291D91472835380B00FCA894 /* MailExampleUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MailExampleUITests.swift; sourceTree = "<group>"; };
 		29FC1CF52822AD2A00F48AA8 /* CustomMailCollectionViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomMailCollectionViewController.swift; sourceTree = "<group>"; };
 		3F234AE31E44AA5E00E22A38 /* MailExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = MailExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		3F234AF21E44AA5E00E22A38 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -55,6 +68,13 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		291D91422835380B00FCA894 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		3F234AE01E44AA5E00E22A38 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -82,11 +102,20 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
+		291D91462835380B00FCA894 /* MailExampleUITests */ = {
+			isa = PBXGroup;
+			children = (
+				291D91472835380B00FCA894 /* MailExampleUITests.swift */,
+			);
+			path = MailExampleUITests;
+			sourceTree = "<group>";
+		};
 		3F234ADA1E44AA5E00E22A38 = {
 			isa = PBXGroup;
 			children = (
 				290FF0B32823EA1500212EAE /* Packages */,
 				3F234AE51E44AA5E00E22A38 /* Source */,
+				291D91462835380B00FCA894 /* MailExampleUITests */,
 				3F234AE41E44AA5E00E22A38 /* Products */,
 				290FF0B72823EA5F00212EAE /* Frameworks */,
 			);
@@ -96,6 +125,7 @@
 			isa = PBXGroup;
 			children = (
 				3F234AE31E44AA5E00E22A38 /* MailExample.app */,
+				291D91452835380B00FCA894 /* MailExampleUITests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -131,6 +161,24 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		291D91442835380B00FCA894 /* MailExampleUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 291D914F2835380B00FCA894 /* Build configuration list for PBXNativeTarget "MailExampleUITests" */;
+			buildPhases = (
+				291D91412835380B00FCA894 /* Sources */,
+				291D91422835380B00FCA894 /* Frameworks */,
+				291D91432835380B00FCA894 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				291D914C2835380B00FCA894 /* PBXTargetDependency */,
+			);
+			name = MailExampleUITests;
+			productName = MailExampleUITests;
+			productReference = 291D91452835380B00FCA894 /* MailExampleUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
 		3F234AE21E44AA5E00E22A38 /* MailExample */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 3F234AF51E44AA5E00E22A38 /* Build configuration list for PBXNativeTarget "MailExample" */;
@@ -157,9 +205,14 @@
 		3F234ADB1E44AA5E00E22A38 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 0820;
+				LastSwiftUpdateCheck = 1320;
 				LastUpgradeCheck = 1100;
 				TargetAttributes = {
+					291D91442835380B00FCA894 = {
+						CreatedOnToolsVersion = 13.2.1;
+						ProvisioningStyle = Automatic;
+						TestTargetID = 3F234AE21E44AA5E00E22A38;
+					};
 					3F234AE21E44AA5E00E22A38 = {
 						CreatedOnToolsVersion = 8.2.1;
 						DevelopmentTeam = 8XNJ93W9ZP;
@@ -182,11 +235,19 @@
 			projectRoot = "";
 			targets = (
 				3F234AE21E44AA5E00E22A38 /* MailExample */,
+				291D91442835380B00FCA894 /* MailExampleUITests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		291D91432835380B00FCA894 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		3F234AE11E44AA5E00E22A38 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -200,6 +261,14 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		291D91412835380B00FCA894 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				291D91482835380B00FCA894 /* MailExampleUITests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		3F234ADF1E44AA5E00E22A38 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -217,7 +286,64 @@
 		};
 /* End PBXSourcesBuildPhase section */
 
+/* Begin PBXTargetDependency section */
+		291D914C2835380B00FCA894 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 3F234AE21E44AA5E00E22A38 /* MailExample */;
+			targetProxy = 291D914B2835380B00FCA894 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
 /* Begin XCBuildConfiguration section */
+		291D914D2835380B00FCA894 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.2;
+				MARKETING_VERSION = 1.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.ilia.MailExampleUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = MailExample;
+			};
+			name = Debug;
+		};
+		291D914E2835380B00FCA894 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.2;
+				MARKETING_VERSION = 1.0;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.ilia.MailExampleUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = MailExample;
+			};
+			name = Release;
+		};
 		3F234AF31E44AA5E00E22A38 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -361,6 +487,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		291D914F2835380B00FCA894 /* Build configuration list for PBXNativeTarget "MailExampleUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				291D914D2835380B00FCA894 /* Debug */,
+				291D914E2835380B00FCA894 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		3F234ADE1E44AA5E00E22A38 /* Build configuration list for PBXProject "MailExample" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/Example/MailExample.xcodeproj/project.pbxproj
+++ b/Example/MailExample.xcodeproj/project.pbxproj
@@ -7,43 +7,29 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		290FF0C12823EB0300212EAE /* SwipeCellKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 290FF0C02823EB0300212EAE /* SwipeCellKit.framework */; };
+		290FF0C22823EB0300212EAE /* SwipeCellKit.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 290FF0C02823EB0300212EAE /* SwipeCellKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		290FF0C72823EBC200212EAE /* RoundedCornersActionContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 290FF0C62823EBC200212EAE /* RoundedCornersActionContentView.swift */; };
+		290FF0C92823EC6000212EAE /* UIColor+Highlighted.swift in Sources */ = {isa = PBXBuildFile; fileRef = 290FF0C82823EC6000212EAE /* UIColor+Highlighted.swift */; };
+		29FC1CF62822AD2A00F48AA8 /* CustomMailCollectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29FC1CF52822AD2A00F48AA8 /* CustomMailCollectionViewController.swift */; };
 		3F234B0A1E44AC2600E22A38 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F234B041E44AC2600E22A38 /* AppDelegate.swift */; };
 		3F234B0B1E44AC2600E22A38 /* MailTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F234B051E44AC2600E22A38 /* MailTableViewController.swift */; };
 		3F234B0C1E44AC2600E22A38 /* Data.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F234B061E44AC2600E22A38 /* Data.swift */; };
 		3F234B0D1E44AC2600E22A38 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 3F234B071E44AC2600E22A38 /* Main.storyboard */; };
 		3F234B0E1E44AC2600E22A38 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 3F234B081E44AC2600E22A38 /* LaunchScreen.storyboard */; };
 		3F234B0F1E44AC2600E22A38 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 3F234B091E44AC2600E22A38 /* Assets.xcassets */; };
-		3F234B171E44B29B00E22A38 /* SwipeCellKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3F234B031E44AB7A00E22A38 /* SwipeCellKit.framework */; };
-		3F234B181E44B29B00E22A38 /* SwipeCellKit.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3F234B031E44AB7A00E22A38 /* SwipeCellKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		B93ECA9D1EDEF1EA00AE05AD /* MailCollectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B93ECA9C1EDEF1EA00AE05AD /* MailCollectionViewController.swift */; };
 		B93ECA9F1EDEF56300AE05AD /* Shared.swift in Sources */ = {isa = PBXBuildFile; fileRef = B93ECA9E1EDEF56300AE05AD /* Shared.swift */; };
 /* End PBXBuildFile section */
 
-/* Begin PBXContainerItemProxy section */
-		3F234B021E44AB7A00E22A38 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 3F234AFE1E44AB7A00E22A38 /* SwipeCellKit.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 3F234AC31E44A7A400E22A38;
-			remoteInfo = SwipeCellKit;
-		};
-		3F234B191E44B29B00E22A38 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 3F234AFE1E44AB7A00E22A38 /* SwipeCellKit.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 3F234AC21E44A7A400E22A38;
-			remoteInfo = SwipeCellKit;
-		};
-/* End PBXContainerItemProxy section */
-
 /* Begin PBXCopyFilesBuildPhase section */
-		3F234B1B1E44B29B00E22A38 /* Embed Frameworks */ = {
+		290FF0C32823EB0300212EAE /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				3F234B181E44B29B00E22A38 /* SwipeCellKit.framework in Embed Frameworks */,
+				290FF0C22823EB0300212EAE /* SwipeCellKit.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -51,11 +37,15 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		290FF0B42823EA1500212EAE /* SwipeCellKit */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = SwipeCellKit; path = ..; sourceTree = "<group>"; };
+		290FF0C02823EB0300212EAE /* SwipeCellKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = SwipeCellKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		290FF0C62823EBC200212EAE /* RoundedCornersActionContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoundedCornersActionContentView.swift; sourceTree = "<group>"; };
+		290FF0C82823EC6000212EAE /* UIColor+Highlighted.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+Highlighted.swift"; sourceTree = "<group>"; };
+		29FC1CF52822AD2A00F48AA8 /* CustomMailCollectionViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomMailCollectionViewController.swift; sourceTree = "<group>"; };
 		3F234AE31E44AA5E00E22A38 /* MailExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = MailExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		3F234AF21E44AA5E00E22A38 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		3F234AFE1E44AB7A00E22A38 /* SwipeCellKit.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = SwipeCellKit.xcodeproj; path = ../SwipeCellKit.xcodeproj; sourceTree = "<group>"; };
 		3F234B041E44AC2600E22A38 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
-		3F234B051E44AC2600E22A38 /* MailTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = MailTableViewController.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
+		3F234B051E44AC2600E22A38 /* MailTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = MailTableViewController.swift; sourceTree = "<group>"; };
 		3F234B061E44AC2600E22A38 /* Data.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Data.swift; sourceTree = "<group>"; };
 		3F234B071E44AC2600E22A38 /* Main.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Main.storyboard; sourceTree = "<group>"; };
 		3F234B081E44AC2600E22A38 /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
@@ -69,19 +59,36 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				3F234B171E44B29B00E22A38 /* SwipeCellKit.framework in Frameworks */,
+				290FF0C12823EB0300212EAE /* SwipeCellKit.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		290FF0B32823EA1500212EAE /* Packages */ = {
+			isa = PBXGroup;
+			children = (
+				290FF0B42823EA1500212EAE /* SwipeCellKit */,
+			);
+			name = Packages;
+			sourceTree = "<group>";
+		};
+		290FF0B72823EA5F00212EAE /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				290FF0C02823EB0300212EAE /* SwipeCellKit.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		3F234ADA1E44AA5E00E22A38 = {
 			isa = PBXGroup;
 			children = (
+				290FF0B32823EA1500212EAE /* Packages */,
 				3F234AE51E44AA5E00E22A38 /* Source */,
 				3F234AE41E44AA5E00E22A38 /* Products */,
-				3F234AFE1E44AB7A00E22A38 /* SwipeCellKit.xcodeproj */,
+				290FF0B72823EA5F00212EAE /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -99,20 +106,15 @@
 				3F234B041E44AC2600E22A38 /* AppDelegate.swift */,
 				3F234B051E44AC2600E22A38 /* MailTableViewController.swift */,
 				B93ECA9C1EDEF1EA00AE05AD /* MailCollectionViewController.swift */,
+				29FC1CF52822AD2A00F48AA8 /* CustomMailCollectionViewController.swift */,
+				290FF0C62823EBC200212EAE /* RoundedCornersActionContentView.swift */,
+				290FF0C82823EC6000212EAE /* UIColor+Highlighted.swift */,
 				B93ECA9E1EDEF56300AE05AD /* Shared.swift */,
 				3F234B061E44AC2600E22A38 /* Data.swift */,
 				3F234B101E44AC3400E22A38 /* Supporting Files */,
 			);
 			name = Source;
 			path = MailExample;
-			sourceTree = "<group>";
-		};
-		3F234AFF1E44AB7A00E22A38 /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				3F234B031E44AB7A00E22A38 /* SwipeCellKit.framework */,
-			);
-			name = Products;
 			sourceTree = "<group>";
 		};
 		3F234B101E44AC3400E22A38 /* Supporting Files */ = {
@@ -136,14 +138,15 @@
 				3F234ADF1E44AA5E00E22A38 /* Sources */,
 				3F234AE01E44AA5E00E22A38 /* Frameworks */,
 				3F234AE11E44AA5E00E22A38 /* Resources */,
-				3F234B1B1E44B29B00E22A38 /* Embed Frameworks */,
+				290FF0C32823EB0300212EAE /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				3F234B1A1E44B29B00E22A38 /* PBXTargetDependency */,
 			);
 			name = MailExample;
+			packageProductDependencies = (
+			);
 			productName = MailExample;
 			productReference = 3F234AE31E44AA5E00E22A38 /* MailExample.app */;
 			productType = "com.apple.product-type.application";
@@ -176,28 +179,12 @@
 			mainGroup = 3F234ADA1E44AA5E00E22A38;
 			productRefGroup = 3F234AE41E44AA5E00E22A38 /* Products */;
 			projectDirPath = "";
-			projectReferences = (
-				{
-					ProductGroup = 3F234AFF1E44AB7A00E22A38 /* Products */;
-					ProjectRef = 3F234AFE1E44AB7A00E22A38 /* SwipeCellKit.xcodeproj */;
-				},
-			);
 			projectRoot = "";
 			targets = (
 				3F234AE21E44AA5E00E22A38 /* MailExample */,
 			);
 		};
 /* End PBXProject section */
-
-/* Begin PBXReferenceProxy section */
-		3F234B031E44AB7A00E22A38 /* SwipeCellKit.framework */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.framework;
-			path = SwipeCellKit.framework;
-			remoteRef = 3F234B021E44AB7A00E22A38 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-/* End PBXReferenceProxy section */
 
 /* Begin PBXResourcesBuildPhase section */
 		3F234AE11E44AA5E00E22A38 /* Resources */ = {
@@ -217,23 +204,18 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				290FF0C72823EBC200212EAE /* RoundedCornersActionContentView.swift in Sources */,
+				29FC1CF62822AD2A00F48AA8 /* CustomMailCollectionViewController.swift in Sources */,
 				B93ECA9F1EDEF56300AE05AD /* Shared.swift in Sources */,
 				3F234B0A1E44AC2600E22A38 /* AppDelegate.swift in Sources */,
 				3F234B0C1E44AC2600E22A38 /* Data.swift in Sources */,
+				290FF0C92823EC6000212EAE /* UIColor+Highlighted.swift in Sources */,
 				3F234B0B1E44AC2600E22A38 /* MailTableViewController.swift in Sources */,
 				B93ECA9D1EDEF1EA00AE05AD /* MailCollectionViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
-
-/* Begin PBXTargetDependency section */
-		3F234B1A1E44B29B00E22A38 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = SwipeCellKit;
-			targetProxy = 3F234B191E44B29B00E22A38 /* PBXContainerItemProxy */;
-		};
-/* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
 		3F234AF31E44AA5E00E22A38 /* Debug */ = {
@@ -284,7 +266,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -337,7 +319,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
@@ -350,12 +332,11 @@
 		3F234AF61E44AA5E00E22A38 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				DEVELOPMENT_TEAM = 8XNJ93W9ZP;
 				INFOPLIST_FILE = MailExample/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.jerkoch.MailExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -366,12 +347,11 @@
 		3F234AF71E44AA5E00E22A38 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				DEVELOPMENT_TEAM = 8XNJ93W9ZP;
 				INFOPLIST_FILE = MailExample/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.jerkoch.MailExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/Example/MailExample.xcodeproj/project.pbxproj
+++ b/Example/MailExample.xcodeproj/project.pbxproj
@@ -13,6 +13,8 @@
 		290FF0C92823EC6000212EAE /* UIColor+Highlighted.swift in Sources */ = {isa = PBXBuildFile; fileRef = 290FF0C82823EC6000212EAE /* UIColor+Highlighted.swift */; };
 		291D91482835380B00FCA894 /* MailExampleUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 291D91472835380B00FCA894 /* MailExampleUITests.swift */; };
 		296D458C28A3DA2B0002C5B5 /* ListPagesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 296D458B28A3DA2B0002C5B5 /* ListPagesViewController.swift */; };
+		A10000010000000000000001 /* SpringRevealActionTransition.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000020000000000000002 /* SpringRevealActionTransition.swift */; };
+		A10000030000000000000003 /* ScalarSpring.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000040000000000000004 /* ScalarSpring.swift */; };
 		29FC1CF62822AD2A00F48AA8 /* CustomMailCollectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29FC1CF52822AD2A00F48AA8 /* CustomMailCollectionViewController.swift */; };
 		3F234B0A1E44AC2600E22A38 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F234B041E44AC2600E22A38 /* AppDelegate.swift */; };
 		3F234B0B1E44AC2600E22A38 /* MailTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F234B051E44AC2600E22A38 /* MailTableViewController.swift */; };
@@ -56,6 +58,8 @@
 		291D91452835380B00FCA894 /* MailExampleUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MailExampleUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		291D91472835380B00FCA894 /* MailExampleUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MailExampleUITests.swift; sourceTree = "<group>"; };
 		296D458B28A3DA2B0002C5B5 /* ListPagesViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListPagesViewController.swift; sourceTree = "<group>"; };
+		A10000020000000000000002 /* SpringRevealActionTransition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpringRevealActionTransition.swift; sourceTree = "<group>"; };
+		A10000040000000000000004 /* ScalarSpring.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScalarSpring.swift; sourceTree = "<group>"; };
 		29FC1CF52822AD2A00F48AA8 /* CustomMailCollectionViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomMailCollectionViewController.swift; sourceTree = "<group>"; };
 		3F234AE31E44AA5E00E22A38 /* MailExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = MailExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		3F234AF21E44AA5E00E22A38 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -140,6 +144,8 @@
 				B93ECA9C1EDEF1EA00AE05AD /* MailCollectionViewController.swift */,
 				29FC1CF52822AD2A00F48AA8 /* CustomMailCollectionViewController.swift */,
 				296D458B28A3DA2B0002C5B5 /* ListPagesViewController.swift */,
+				A10000020000000000000002 /* SpringRevealActionTransition.swift */,
+				A10000040000000000000004 /* ScalarSpring.swift */,
 				290FF0C62823EBC200212EAE /* RoundedCornersActionContentView.swift */,
 				290FF0C82823EC6000212EAE /* UIColor+Highlighted.swift */,
 				B93ECA9E1EDEF56300AE05AD /* Shared.swift */,
@@ -280,6 +286,8 @@
 				29FC1CF62822AD2A00F48AA8 /* CustomMailCollectionViewController.swift in Sources */,
 				B93ECA9F1EDEF56300AE05AD /* Shared.swift in Sources */,
 				296D458C28A3DA2B0002C5B5 /* ListPagesViewController.swift in Sources */,
+				A10000010000000000000001 /* SpringRevealActionTransition.swift in Sources */,
+				A10000030000000000000003 /* ScalarSpring.swift in Sources */,
 				3F234B0A1E44AC2600E22A38 /* AppDelegate.swift in Sources */,
 				3F234B0C1E44AC2600E22A38 /* Data.swift in Sources */,
 				290FF0C92823EC6000212EAE /* UIColor+Highlighted.swift in Sources */,

--- a/Example/MailExample.xcodeproj/xcshareddata/xcschemes/MailExample.xcscheme
+++ b/Example/MailExample.xcodeproj/xcshareddata/xcschemes/MailExample.xcscheme
@@ -37,6 +37,16 @@
          </BuildableReference>
       </MacroExpansion>
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "291D91442835380B00FCA894"
+               BuildableName = "MailExampleUITests.xctest"
+               BlueprintName = "MailExampleUITests"
+               ReferencedContainer = "container:MailExample.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/Example/MailExample/CustomMailCollectionViewController.swift
+++ b/Example/MailExample/CustomMailCollectionViewController.swift
@@ -1,0 +1,267 @@
+//
+//  MailCollectionViewController.swift
+//
+//  Created by Jeremy Koch
+//  Copyright © 2017 Jeremy Koch. All rights reserved.
+//
+
+import UIKit
+import SwipeCellKit
+
+class CustomMailCollectionViewController: UICollectionViewController, UICollectionViewDelegateFlowLayout {
+    var emails: [Email] = []
+    
+    var defaultOptions = SwipeOptions()
+    var isSwipeRightEnabled = true
+    var buttonDisplayMode: ButtonDisplayMode = .titleAndImage
+    var buttonStyle: ButtonStyle = .backgroundColor
+    var usesTallCells = false
+    
+    // MARK: - Lifecycle
+    
+    override func viewDidLoad() {
+        navigationItem.rightBarButtonItem = editButtonItem
+        
+        resetData()
+    }
+    
+    // MARK: - Collection view data source
+    override func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        return emails.count
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+        return CGSize(width: collectionView.frame.width, height: usesTallCells ? 160 : 98)
+    }
+    
+    override func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        let email = emails[indexPath.row]
+        
+        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "MailCell", for: indexPath) as! CustomMailCollectionViewCell
+        
+        cell.delegate = self
+        cell.selectedBackgroundView = UIView()
+        cell.selectedBackgroundView?.backgroundColor = UIColor.lightGray.withAlphaComponent(0.2)
+        
+        cell.fromLabel.text = email.from
+        cell.dateLabel.text = email.relativeDateString
+        cell.subjectLabel.text = email.subject
+        cell.bodyLabel.text = email.body
+        cell.bodyLabel.numberOfLines = usesTallCells ? 0 : 2
+        cell.unread = email.unread
+        
+        return cell
+    }
+    
+    // MARK: - Actions
+    
+    @IBAction func moreTapped(_ sender: Any) {
+        let controller = UIAlertController(title: "Swipe Transition Style", message: nil, preferredStyle: .actionSheet)
+        controller.addAction(UIAlertAction(title: "Border", style: .default, handler: { _ in self.defaultOptions.transitionStyle = .border }))
+        controller.addAction(UIAlertAction(title: "Drag", style: .default, handler: { _ in self.defaultOptions.transitionStyle = .drag }))
+        controller.addAction(UIAlertAction(title: "Reveal", style: .default, handler: { _ in self.defaultOptions.transitionStyle = .reveal }))
+        controller.addAction(UIAlertAction(title: "\(isSwipeRightEnabled ? "Disable" : "Enable") Swipe Right", style: .default, handler: { _ in self.isSwipeRightEnabled = !self.isSwipeRightEnabled }))
+        controller.addAction(UIAlertAction(title: "Button Display Mode", style: .default, handler: { _ in self.buttonDisplayModeTapped() }))
+        controller.addAction(UIAlertAction(title: "Button Style", style: .default, handler: { _ in self.buttonStyleTapped() }))
+        controller.addAction(UIAlertAction(title: "Cell Height", style: .default, handler: { _ in self.cellHeightTapped() }))
+        controller.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: nil))
+        controller.addAction(UIAlertAction(title: "Reset", style: .destructive, handler: { _ in self.resetData() }))
+        present(controller, animated: true, completion: nil)
+    }
+    
+    func buttonDisplayModeTapped() {
+        let controller = UIAlertController(title: "Button Display Mode", message: nil, preferredStyle: .actionSheet)
+        controller.addAction(UIAlertAction(title: "Image + Title", style: .default, handler: { _ in self.buttonDisplayMode = .titleAndImage }))
+        controller.addAction(UIAlertAction(title: "Image Only", style: .default, handler: { _ in self.buttonDisplayMode = .imageOnly }))
+        controller.addAction(UIAlertAction(title: "Title Only", style: .default, handler: { _ in self.buttonDisplayMode = .titleOnly }))
+        controller.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: nil))
+        present(controller, animated: true, completion: nil)
+    }
+    
+    func buttonStyleTapped() {
+        let controller = UIAlertController(title: "Button Style", message: nil, preferredStyle: .actionSheet)
+        controller.addAction(UIAlertAction(title: "Background Color", style: .default, handler: { _ in
+            self.buttonStyle = .backgroundColor
+            self.defaultOptions.transitionStyle = .border
+        }))
+        controller.addAction(UIAlertAction(title: "Circular", style: .default, handler: { _ in
+            self.buttonStyle = .circular
+            self.defaultOptions.transitionStyle = .reveal
+        }))
+        controller.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: nil))
+        present(controller, animated: true, completion: nil)
+    }
+    
+    func cellHeightTapped() {
+        let controller = UIAlertController(title: "Cell Height", message: nil, preferredStyle: .actionSheet)
+        controller.addAction(UIAlertAction(title: "Normal", style: .default, handler: { _ in
+            self.usesTallCells = false
+            self.collectionView?.reloadData()
+        }))
+        controller.addAction(UIAlertAction(title: "Tall", style: .default, handler: { _ in
+            self.usesTallCells = true
+            self.collectionView?.reloadData()
+        }))
+        controller.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: nil))
+        present(controller, animated: true, completion: nil)
+    }
+    
+    func resetData() {
+        emails = mockEmails
+        emails.forEach { $0.unread = false }
+        usesTallCells = false
+        collectionView?.reloadData()
+    }
+}
+
+extension CustomMailCollectionViewController: SwipeCollectionViewCellDelegate {
+    
+    func collectionView(_ collectionView: UICollectionView, editActionsForItemAt indexPath: IndexPath, for orientation: SwipeActionsOrientation) -> [SwipeAction]? {
+        let email = emails[indexPath.row]
+        
+        if orientation == .left {
+            guard isSwipeRightEnabled else { return nil }
+            
+            let read = SwipeAction(style: .default, title: nil) { action, indexPath in
+                let updatedStatus = !email.unread
+                email.unread = updatedStatus
+                
+                let cell = collectionView.cellForItem(at: indexPath) as! CustomMailCollectionViewCell
+                cell.setUnread(updatedStatus, animated: true)
+            }
+            
+            read.hidesWhenSelected = true
+            read.accessibilityLabel = email.unread ? "Mark as Read" : "Mark as Unread"
+            
+            let descriptor: ActionDescriptor = email.unread ? .read : .unread
+            configure(action: read, with: descriptor)
+            
+            return [read]
+        } else {
+            let flag = SwipeAction(style: .default, title: nil, handler: nil)
+            flag.hidesWhenSelected = true
+            configure(action: flag, with: .flag)
+            
+            let delete = SwipeAction(style: .destructive, title: nil) { action, indexPath in
+                self.emails.remove(at: indexPath.row)
+            }
+            configure(action: delete, with: .trash)
+            
+            let cell = collectionView.cellForItem(at: indexPath) as! CustomMailCollectionViewCell
+            let closure: (UIAlertAction) -> Void = { _ in cell.hideSwipe(animated: true) }
+            let more = SwipeAction(style: .default, title: nil) { action, indexPath in
+                let controller = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
+                controller.addAction(UIAlertAction(title: "Reply", style: .default, handler: closure))
+                controller.addAction(UIAlertAction(title: "Forward", style: .default, handler: closure))
+                controller.addAction(UIAlertAction(title: "Mark...", style: .default, handler: closure))
+                controller.addAction(UIAlertAction(title: "Notify Me...", style: .default, handler: closure))
+                controller.addAction(UIAlertAction(title: "Move Message...", style: .default, handler: closure))
+                controller.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: closure))
+                self.present(controller, animated: true, completion: nil)
+            }
+            configure(action: more, with: .more)
+            
+            return [delete, flag, more]
+        }
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, editActionsOptionsForItemAt indexPath: IndexPath, for orientation: SwipeActionsOrientation) -> SwipeOptions {
+        var options = SwipeOptions()
+        options.expansionStyle = orientation == .left ? .selection : .destructive
+        options.transitionStyle = defaultOptions.transitionStyle
+
+        options.backgroundColor = .clear
+        options.buttonVerticalAlignment = .center
+        
+        return options
+    }
+
+    func collectionView(
+        _ collectionView: UICollectionView,
+        contentViewForAction action: SwipeAction
+    ) -> ActionContentView {
+        RoundedCornersActionContentView(action: action)
+    }
+    
+    func visibleRect(for collectionView: UICollectionView) -> CGRect? {
+        if usesTallCells == false { return nil }
+        
+        if #available(iOS 11.0, *) {
+            return collectionView.safeAreaLayoutGuide.layoutFrame
+        } else {
+            let topInset = navigationController?.navigationBar.frame.height ?? 0
+            let bottomInset = navigationController?.toolbar?.frame.height ?? 0
+            let bounds = collectionView.bounds
+            
+            return CGRect(x: bounds.origin.x, y: bounds.origin.y + topInset, width: bounds.width, height: bounds.height - bottomInset)
+        }
+    }
+    
+    func configure(action: SwipeAction, with descriptor: ActionDescriptor) {
+        action.title = descriptor.title(forDisplayMode: buttonDisplayMode)
+        action.image = descriptor.image(forStyle: buttonStyle, displayMode: buttonDisplayMode)
+        
+        switch buttonStyle {
+        case .backgroundColor:
+            action.backgroundColor = descriptor.color(forStyle: buttonStyle)
+        case .circular:
+            action.backgroundColor = .clear
+            action.textColor = descriptor.color(forStyle: buttonStyle)
+            action.font = .systemFont(ofSize: 13)
+            action.transitionDelegate = ScaleTransition.default
+        }
+    }
+}
+
+class CustomMailCollectionViewCell: SwipeCollectionViewCell {
+    @IBOutlet var fromLabel: UILabel!
+    @IBOutlet var dateLabel: UILabel!
+    @IBOutlet var subjectLabel: UILabel!
+    @IBOutlet var bodyLabel: UILabel!
+    
+    var animator: Any?
+    
+    var indicatorView = IndicatorView(frame: .zero)
+    
+    var unread = false {
+        didSet {
+            indicatorView.transform = unread ? CGAffineTransform.identity : CGAffineTransform.init(scaleX: 0.001, y: 0.001)
+        }
+    }
+    
+    override func awakeFromNib() {
+        setupIndicatorView()
+    }
+    
+    func setupIndicatorView() {
+        indicatorView.translatesAutoresizingMaskIntoConstraints = false
+        indicatorView.color = tintColor
+        indicatorView.backgroundColor = .clear
+        contentView.addSubview(indicatorView)
+        
+        let size: CGFloat = 12
+        indicatorView.widthAnchor.constraint(equalToConstant: size).isActive = true
+        indicatorView.heightAnchor.constraint(equalTo: indicatorView.widthAnchor).isActive = true
+        indicatorView.leftAnchor.constraint(equalTo: contentView.leftAnchor, constant: 12).isActive = true
+        indicatorView.centerYAnchor.constraint(equalTo: fromLabel.centerYAnchor).isActive = true
+    }
+    
+    func setUnread(_ unread: Bool, animated: Bool) {
+        let closure = {
+            self.unread = unread
+        }
+        
+        if #available(iOS 10, *), animated {
+            var localAnimator = self.animator as? UIViewPropertyAnimator
+            localAnimator?.stopAnimation(true)
+            
+            localAnimator = unread ? UIViewPropertyAnimator(duration: 1.0, dampingRatio: 0.4) : UIViewPropertyAnimator(duration: 0.3, dampingRatio: 1.0)
+            localAnimator?.addAnimations(closure)
+            localAnimator?.startAnimation()
+            
+            self.animator = localAnimator
+        } else {
+            closure()
+        }
+    }
+}

--- a/Example/MailExample/CustomMailCollectionViewController.swift
+++ b/Example/MailExample/CustomMailCollectionViewController.swift
@@ -140,6 +140,7 @@ extension CustomMailCollectionViewController: SwipeCollectionViewCellDelegate {
         } else {
             let flag = SwipeAction(style: .default, title: nil, handler: nil)
             flag.hidesWhenSelected = true
+            flag.accessibilityLabel = "Accessible Button"
             configure(action: flag, with: .flag)
             
             let delete = SwipeAction(style: .destructive, title: nil) { action, indexPath in

--- a/Example/MailExample/CustomMailCollectionViewController.swift
+++ b/Example/MailExample/CustomMailCollectionViewController.swift
@@ -16,11 +16,25 @@ class CustomMailCollectionViewController: UICollectionViewController, UICollecti
     var buttonDisplayMode: ButtonDisplayMode = .titleAndImage
     var buttonStyle: ButtonStyle = .backgroundColor
     var usesTallCells = false
-    
+    private let isManualMode: Bool
+
+    init() {
+        isManualMode = true
+        super.init(collectionViewLayout: UICollectionViewFlowLayout())
+    }
+
+    required init?(coder: NSCoder) {
+        isManualMode = false
+        super.init(coder: coder)
+    }
+
     // MARK: - Lifecycle
     
     override func viewDidLoad() {
         navigationItem.rightBarButtonItem = editButtonItem
+        if isManualMode {
+            collectionView.register(CustomMailCollectionViewCell.self, forCellWithReuseIdentifier: "MailCell")
+        }
         
         resetData()
     }
@@ -38,6 +52,9 @@ class CustomMailCollectionViewController: UICollectionViewController, UICollecti
         let email = emails[indexPath.row]
         
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "MailCell", for: indexPath) as! CustomMailCollectionViewCell
+        if isManualMode {
+            cell.setupViews()
+        }
         
         cell.delegate = self
         cell.selectedBackgroundView = UIView()
@@ -232,7 +249,57 @@ class CustomMailCollectionViewCell: SwipeCollectionViewCell {
             indicatorView.transform = unread ? CGAffineTransform.identity : CGAffineTransform.init(scaleX: 0.001, y: 0.001)
         }
     }
-    
+
+    func setupViews() {
+        fromLabel = UILabel()
+        fromLabel.font = .preferredFont(forTextStyle: .headline)
+        fromLabel.textColor = .label
+        dateLabel = UILabel()
+        dateLabel.font = .preferredFont(forTextStyle: .subheadline)
+        dateLabel.textColor = .secondaryLabel
+        subjectLabel = UILabel()
+        subjectLabel.font = .preferredFont(forTextStyle: .subheadline)
+        subjectLabel.textColor = .label
+        bodyLabel = UILabel()
+        bodyLabel.font = .preferredFont(forTextStyle: .subheadline)
+        bodyLabel.textColor = .secondaryLabel
+
+        let hStack = UIStackView(arrangedSubviews: [
+            fromLabel,
+            dateLabel,
+            UIImageView(image: UIImage(named: "Disclosure")!)
+        ])
+        hStack.axis = .horizontal
+        hStack.spacing = 6
+
+        let vStack = UIStackView(arrangedSubviews: [
+            hStack,
+            subjectLabel,
+            bodyLabel
+        ])
+        vStack.axis = .vertical
+        vStack.spacing = 2
+
+        contentView.addSubview(vStack)
+        let separator = UIView()
+        separator.backgroundColor = .separator
+        separator.translatesAutoresizingMaskIntoConstraints = false
+        contentView.addSubview(separator)
+
+        vStack.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            vStack.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 24),
+            vStack.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -24),
+            vStack.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 4),
+            vStack.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: 4),
+            separator.leadingAnchor.constraint(equalTo: vStack.leadingAnchor),
+            separator.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+            separator.heightAnchor.constraint(equalToConstant: 0.5)
+        ])
+
+        setupIndicatorView()
+    }
+
     override func awakeFromNib() {
         setupIndicatorView()
     }

--- a/Example/MailExample/CustomMailCollectionViewController.swift
+++ b/Example/MailExample/CustomMailCollectionViewController.swift
@@ -24,7 +24,7 @@ class CustomMailCollectionViewController: UICollectionViewController, UICollecti
         
         resetData()
     }
-    
+
     // MARK: - Collection view data source
     override func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         return emails.count
@@ -173,6 +173,9 @@ extension CustomMailCollectionViewController: SwipeCollectionViewCellDelegate {
 
         options.backgroundColor = .clear
         options.buttonVerticalAlignment = .center
+        options.edgeInsets = .init(top: 2, left: 0, bottom: 2, right: 0)
+        options.rightSwipeAreaMultiplier = 0.3
+        options.leftSwipeAreaMultiplier = 0.2
         
         return options
     }

--- a/Example/MailExample/CustomMailCollectionViewController.swift
+++ b/Example/MailExample/CustomMailCollectionViewController.swift
@@ -174,8 +174,8 @@ extension CustomMailCollectionViewController: SwipeCollectionViewCellDelegate {
         options.backgroundColor = .clear
         options.buttonVerticalAlignment = .center
         options.edgeInsets = .init(top: 2, left: 0, bottom: 2, right: 0)
-        options.rightSwipeAreaMultiplier = 0.3
-        options.leftSwipeAreaMultiplier = 0.2
+        options.rightPanZone = .fractional(0.3)
+        options.leftPanZone = .absolute(100)
         
         return options
     }

--- a/Example/MailExample/CustomMailCollectionViewController.swift
+++ b/Example/MailExample/CustomMailCollectionViewController.swift
@@ -14,17 +14,19 @@ class CustomMailCollectionViewController: UICollectionViewController, UICollecti
     var defaultOptions = SwipeOptions()
     var isSwipeRightEnabled = true
     var buttonDisplayMode: ButtonDisplayMode = .titleAndImage
-    var buttonStyle: ButtonStyle = .backgroundColor
+    var buttonStyle: ButtonStyle = .circular
     var usesTallCells = false
     private let isManualMode: Bool
 
     init() {
         isManualMode = true
+        defaultOptions.transitionStyle = .reveal
         super.init(collectionViewLayout: UICollectionViewFlowLayout())
     }
 
     required init?(coder: NSCoder) {
         isManualMode = false
+        defaultOptions.transitionStyle = .reveal
         super.init(coder: coder)
     }
 
@@ -135,6 +137,7 @@ extension CustomMailCollectionViewController: SwipeCollectionViewCellDelegate {
     
     func collectionView(_ collectionView: UICollectionView, editActionsForItemAt indexPath: IndexPath, for orientation: SwipeActionsOrientation) -> [SwipeAction]? {
         let email = emails[indexPath.row]
+        let actionDisplayMode = displayModeForActions(in: collectionView, at: indexPath)
         
         if orientation == .left {
             guard isSwipeRightEnabled else { return nil }
@@ -151,19 +154,19 @@ extension CustomMailCollectionViewController: SwipeCollectionViewCellDelegate {
             read.accessibilityLabel = email.unread ? "Mark as Read" : "Mark as Unread"
             
             let descriptor: ActionDescriptor = email.unread ? .read : .unread
-            configure(action: read, with: descriptor)
+            configure(action: read, with: descriptor, displayMode: actionDisplayMode)
             
             return [read]
         } else {
             let flag = SwipeAction(style: .default, title: nil, handler: nil)
             flag.hidesWhenSelected = true
             flag.accessibilityLabel = "Accessible Button"
-            configure(action: flag, with: .flag)
+            configure(action: flag, with: .flag, displayMode: actionDisplayMode)
             
             let delete = SwipeAction(style: .destructive, title: nil) { action, indexPath in
                 self.emails.remove(at: indexPath.row)
             }
-            configure(action: delete, with: .trash)
+            configure(action: delete, with: .trash, displayMode: actionDisplayMode)
             
             let cell = collectionView.cellForItem(at: indexPath) as! CustomMailCollectionViewCell
             let closure: (UIAlertAction) -> Void = { _ in cell.hideSwipe(animated: true) }
@@ -177,7 +180,7 @@ extension CustomMailCollectionViewController: SwipeCollectionViewCellDelegate {
                 controller.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: closure))
                 self.present(controller, animated: true, completion: nil)
             }
-            configure(action: more, with: .more)
+            configure(action: more, with: .more, displayMode: actionDisplayMode)
             
             return [delete, flag, more]
         }
@@ -185,14 +188,24 @@ extension CustomMailCollectionViewController: SwipeCollectionViewCellDelegate {
     
     func collectionView(_ collectionView: UICollectionView, editActionsOptionsForItemAt indexPath: IndexPath, for orientation: SwipeActionsOrientation) -> SwipeOptions {
         var options = SwipeOptions()
-        options.expansionStyle = orientation == .left ? .selection : .destructive
+        var expansionStyle: SwipeExpansionStyle = orientation == .left ? .selection : .destructive
+        expansionStyle.expandedActionLayout = .fillAvailableSpace
+        options.expansionStyle = expansionStyle
+        options.expansionDelegate = SecondaryActionsExpansion()
         options.transitionStyle = defaultOptions.transitionStyle
+        options.activationThreshold = .absolute(24)
 
         options.backgroundColor = .clear
+        options.buttonWidthMode = .individual
         options.buttonVerticalAlignment = .center
         options.edgeInsets = .init(top: 2, left: 0, bottom: 2, right: 0)
         options.rightPanZone = .fractional(0.3)
         options.leftPanZone = .absolute(100)
+
+        if buttonStyle == .circular {
+            options.minimumButtonWidth = 20
+            options.maximumButtonWidth = 90
+        }
         
         return options
     }
@@ -217,11 +230,26 @@ extension CustomMailCollectionViewController: SwipeCollectionViewCellDelegate {
             return CGRect(x: bounds.origin.x, y: bounds.origin.y + topInset, width: bounds.width, height: bounds.height - bottomInset)
         }
     }
-    
-    func configure(action: SwipeAction, with descriptor: ActionDescriptor) {
-        action.title = descriptor.title(forDisplayMode: buttonDisplayMode)
-        action.image = descriptor.image(forStyle: buttonStyle, displayMode: buttonDisplayMode)
-        
+
+    private func displayModeForActions(
+        in collectionView: UICollectionView,
+        at indexPath: IndexPath
+    ) -> ButtonDisplayMode {
+        guard let cellHeight = collectionView.layoutAttributesForItem(at: indexPath)?.bounds.height else {
+            return buttonDisplayMode
+        }
+
+        return cellHeight < 120 ? .titleOnly : buttonDisplayMode
+    }
+
+    func configure(
+        action: SwipeAction,
+        with descriptor: ActionDescriptor,
+        displayMode: ButtonDisplayMode
+    ) {
+        action.title = descriptor.title(forDisplayMode: displayMode)
+        action.image = descriptor.image(forStyle: .backgroundColor, displayMode: displayMode)
+
         switch buttonStyle {
         case .backgroundColor:
             action.backgroundColor = descriptor.color(forStyle: buttonStyle)
@@ -229,7 +257,34 @@ extension CustomMailCollectionViewController: SwipeCollectionViewCellDelegate {
             action.backgroundColor = .clear
             action.textColor = descriptor.color(forStyle: buttonStyle)
             action.font = .systemFont(ofSize: 13)
-            action.transitionDelegate = ScaleTransition.default
+            action.transitionDelegate = SpringRevealActionTransition()
+        }
+    }
+}
+
+private struct SecondaryActionsExpansion: SwipeExpanding {
+    func animationTimingParameters(
+        buttons: [UIView],
+        expanding: Bool
+    ) -> SwipeExpansionAnimationTimingParameters {
+        SwipeExpansionAnimationTimingParameters(duration: 0.15)
+    }
+
+    func actionButton(
+        _ button: UIView,
+        didChange expanding: Bool,
+        otherActionButtons: [UIView]
+    ) {
+        otherActionButtons.forEach { button in
+            UIView.animate(
+                withDuration: 0.15,
+                delay: 0,
+                options: [.beginFromCurrentState, .allowUserInteraction],
+                animations: {
+                    button.alpha = expanding ? 0.5 : 1
+                },
+                completion: nil
+            )
         }
     }
 }

--- a/Example/MailExample/ListPagesViewController.swift
+++ b/Example/MailExample/ListPagesViewController.swift
@@ -1,0 +1,157 @@
+//
+//  ListPagesViewController.swift
+//  MailExample
+//
+//  Created by Ilia Sedov on 10.08.2022.
+//
+
+import Foundation
+import UIKit
+
+final class ListPagesViewController: UIViewController {
+    private var pagesDataSource: PagesDataSource!
+    private var pagesViewController: UIPageViewController!
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        pagesDataSource = .init()
+        pagesViewController = createPagesViewController()
+
+        addChild(pagesViewController)
+        pagesViewController.view.embedTo(parentView: view)
+        pagesViewController.didMove(toParent: self)
+
+        navigationItem.rightBarButtonItems = [
+            UIBarButtonItem(
+                barButtonSystemItem: .fastForward,
+                target: self,
+                action: #selector(showNext)
+            ),
+            UIBarButtonItem(
+                barButtonSystemItem: .rewind,
+                target: self,
+                action: #selector(showPrev)
+            )
+        ]
+    }
+
+    @objc
+    private func showPrev() {
+        guard let currentController = pagesViewController.viewControllers?.first,
+              let nextController = pagesDataSource.pageViewController(
+                pagesViewController,
+                viewControllerBefore: currentController
+              )
+        else { return }
+
+        pagesViewController.setViewControllers(
+            [nextController],
+            direction: .reverse,
+            animated: true,
+            completion: nil
+        )
+    }
+
+    @objc
+    private func showNext() {
+        guard let currentController = pagesViewController.viewControllers?.first,
+              let nextController = pagesDataSource.pageViewController(
+                pagesViewController,
+                viewControllerAfter: currentController
+              )
+        else { return }
+
+        pagesViewController.setViewControllers(
+            [nextController],
+            direction: .forward,
+            animated: true,
+            completion: nil
+        )
+    }
+
+    private func createPagesViewController() -> UIPageViewController {
+        let pagesController = UIPageViewController(
+            transitionStyle: .scroll,
+            navigationOrientation: .horizontal,
+            options: [.interPageSpacing: 16]
+        )
+        pagesController.dataSource = pagesDataSource
+        pagesController
+            .setViewControllers(
+                [pagesDataSource.initialController],
+                direction: .forward,
+                animated: false,
+                completion: nil
+            )
+        return pagesController
+    }
+}
+
+class PagesDataSource: NSObject, UIPageViewControllerDataSource {
+    private let controllers: [UIViewController]
+
+    private static func isListController(_ viewController: UIViewController) -> Bool {
+        viewController is CustomMailCollectionViewController
+    }
+
+    private static func getListContentController() -> UIViewController {
+        CustomMailCollectionViewController()
+    }
+
+    private static func getDummyController() -> UIViewController {
+        let controller = UIViewController()
+        controller.view.backgroundColor = .purple
+        let caption = UILabel()
+        caption.font = .preferredFont(forTextStyle: .caption1)
+        caption.text = "Dummy"
+        caption.textColor = .white
+        caption.backgroundColor = .clear
+        caption.embedTo(parentView: controller.view)
+        return controller
+    }
+
+    override init() {
+        controllers = [
+            Self.getListContentController(),
+            Self.getDummyController()
+        ]
+    }
+
+    var initialController: UIViewController {
+        controllers.first!
+    }
+
+    func pageViewController(
+        _ pageViewController: UIPageViewController,
+        viewControllerBefore viewController: UIViewController
+    ) -> UIViewController? {
+        if Self.isListController(viewController) {
+            return nil
+        }
+        return controllers.first
+    }
+
+    func pageViewController(
+        _ pageViewController: UIPageViewController,
+        viewControllerAfter viewController: UIViewController
+    ) -> UIViewController? {
+        if Self.isListController(viewController) {
+            return controllers.last
+        }
+        return nil
+    }
+}
+
+
+extension UIView {
+    func embedTo(parentView: UIView) {
+        parentView.addSubview(self)
+        translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            leadingAnchor.constraint(equalTo: parentView.leadingAnchor),
+            trailingAnchor.constraint(equalTo: parentView.trailingAnchor),
+            topAnchor.constraint(equalTo: parentView.safeAreaLayoutGuide.topAnchor),
+            bottomAnchor.constraint(equalTo: parentView.safeAreaLayoutGuide.bottomAnchor)
+        ])
+    }
+}

--- a/Example/MailExample/Main.storyboard
+++ b/Example/MailExample/Main.storyboard
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14868" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="LX8-Wu-PZs">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="LX8-Wu-PZs">
     <device id="retina5_5" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14824"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -14,35 +15,35 @@
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="141" sectionHeaderHeight="28" sectionFooterHeight="28" id="CnD-MW-SLC">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="736"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="MailCell" rowHeight="141" id="5Yy-lT-eDE" customClass="MailCell" customModule="MailExample" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="28" width="414" height="141"/>
+                                <rect key="frame" x="0.0" y="44.666666030883789" width="414" height="141"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" tableViewCell="5Yy-lT-eDE" id="4sX-Fn-82y">
                                     <rect key="frame" x="0.0" y="0.0" width="414" height="141"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacing="2" translatesAutoresizingMaskIntoConstraints="NO" id="QLZ-ve-Blz">
-                                            <rect key="frame" x="20" y="8" width="366" height="80.333333333333329"/>
+                                            <rect key="frame" x="20" y="8" width="366" height="65.666666666666671"/>
                                             <subviews>
                                                 <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="mEo-oH-eCL">
-                                                    <rect key="frame" x="0.0" y="0.0" width="366" height="20.333333333333332"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="366" height="17"/>
                                                     <subviews>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="252" verticalHuggingPriority="251" verticalCompressionResistancePriority="751" text="John Doe" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="C77-Oi-r7Y">
-                                                            <rect key="frame" x="0.0" y="0.0" width="75.666666666666671" height="20.333333333333332"/>
+                                                            <rect key="frame" x="0.0" y="0.0" width="63.666666666666664" height="17"/>
                                                             <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                                                             <nil key="textColor"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="12:16 AM" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MgJ-f3-Qel">
-                                                            <rect key="frame" x="81.666666666666657" y="1.3333333333333339" width="264.33333333333337" height="18"/>
+                                                            <rect key="frame" x="69.666666666666657" y="1.333333333333333" width="276.33333333333337" height="14.333333333333336"/>
                                                             <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
-                                                            <color key="textColor" systemColor="secondaryLabelColor" red="0.23529411764705882" green="0.23529411764705882" blue="0.2627450980392157" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
+                                                            <color key="textColor" systemColor="secondaryLabelColor"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
                                                         <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="Disclosure" translatesAutoresizingMaskIntoConstraints="NO" id="UNG-rq-ulh">
-                                                            <rect key="frame" x="352" y="3.3333333333333339" width="14" height="14.000000000000002"/>
+                                                            <rect key="frame" x="352" y="1.6666666666666661" width="14" height="14"/>
                                                             <constraints>
                                                                 <constraint firstAttribute="width" constant="14" id="Ty6-tZ-2ee"/>
                                                                 <constraint firstAttribute="height" constant="14" id="eoh-QM-XJN"/>
@@ -51,16 +52,16 @@
                                                     </subviews>
                                                 </stackView>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Fwd: Jane's independent studies" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="kOp-Z7-e55">
-                                                    <rect key="frame" x="0.0" y="22.333333333333332" width="224.33333333333334" height="17.999999999999996"/>
+                                                    <rect key="frame" x="0.0" y="19" width="186" height="14.333333333333336"/>
                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="751" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wyD-6Z-4MU">
-                                                    <rect key="frame" x="0.0" y="42.333333333333336" width="360" height="38.000000000000007"/>
+                                                    <rect key="frame" x="0.0" y="35.333333333333336" width="364.33333333333331" height="30.333333333333336"/>
                                                     <string key="text">Sra. Mendez - Thank you so MUCH for this.  We know you do not have to do this and we are so grateful to you.  Please let us know if there's anything else we can do.</string>
                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
-                                                    <color key="textColor" systemColor="secondaryLabelColor" red="0.23529411764705882" green="0.23529411764705882" blue="0.2627450980392157" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <color key="textColor" systemColor="secondaryLabelColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                             </subviews>
@@ -172,14 +173,14 @@
                             <tableViewSection id="iR0-38-MTh">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="rW1-t9-nrA" style="IBUITableViewCellStyleDefault" id="Kgd-u6-cy7">
-                                        <rect key="frame" x="0.0" y="28" width="414" height="44"/>
+                                        <rect key="frame" x="0.0" y="44.666666030883789" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="Kgd-u6-cy7" id="WoI-9A-iYC">
-                                            <rect key="frame" x="0.0" y="0.0" width="382.66666666666669" height="44"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="385.33333333333331" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="UITableView Example" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="rW1-t9-nrA">
-                                                    <rect key="frame" x="20" y="0.0" width="354.66666666666669" height="44"/>
+                                                    <rect key="frame" x="20" y="0.0" width="357.33333333333331" height="44"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                     <nil key="textColor"/>
@@ -192,14 +193,14 @@
                                         </connections>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="tAo-zE-slr" style="IBUITableViewCellStyleDefault" id="v7C-GF-bE4">
-                                        <rect key="frame" x="0.0" y="72" width="414" height="44"/>
+                                        <rect key="frame" x="0.0" y="88.666666030883789" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="v7C-GF-bE4" id="8JL-hE-Ezo">
-                                            <rect key="frame" x="0.0" y="0.0" width="382.66666666666669" height="44"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="385.33333333333331" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="UICollectionView Example" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="tAo-zE-slr">
-                                                    <rect key="frame" x="20" y="0.0" width="354.66666666666669" height="44"/>
+                                                    <rect key="frame" x="20" y="0.0" width="357.33333333333331" height="44"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                     <nil key="textColor"/>
@@ -209,6 +210,26 @@
                                         </tableViewCellContentView>
                                         <connections>
                                             <segue destination="w79-7A-sTS" kind="show" id="z0J-zs-jgy"/>
+                                        </connections>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="QUM-l0-miT" style="IBUITableViewCellStyleDefault" id="xSs-lf-ARr">
+                                        <rect key="frame" x="0.0" y="132.66666603088379" width="414" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="xSs-lf-ARr" id="hTu-oG-mck">
+                                            <rect key="frame" x="0.0" y="0.0" width="385.33333333333331" height="44"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Custom Content Action Collection" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="QUM-l0-miT">
+                                                    <rect key="frame" x="20" y="0.0" width="357.33333333333331" height="44"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                        <connections>
+                                            <segue destination="L77-gb-JYx" kind="show" id="HlL-CN-ByY"/>
                                         </connections>
                                     </tableViewCell>
                                 </cells>
@@ -232,7 +253,7 @@
                     <collectionView key="view" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" id="Nen-BV-WtC">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="736"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="0.0" minimumInteritemSpacing="0.0" sectionInsetReference="safeArea" id="Nkq-D0-kpn">
                             <size key="itemSize" width="414" height="98"/>
                             <size key="headerReferenceSize" width="0.0" height="0.0"/>
@@ -248,25 +269,25 @@
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacing="2" translatesAutoresizingMaskIntoConstraints="NO" id="ysl-94-klK">
-                                            <rect key="frame" x="32" y="8" width="366" height="80.333333333333329"/>
+                                            <rect key="frame" x="32" y="8" width="366" height="65.666666666666671"/>
                                             <subviews>
                                                 <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="5uQ-2a-OAe">
-                                                    <rect key="frame" x="0.0" y="0.0" width="366" height="20.333333333333332"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="366" height="17"/>
                                                     <subviews>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="252" verticalHuggingPriority="251" text="John Doe" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sfg-MB-yOh">
-                                                            <rect key="frame" x="0.0" y="0.0" width="75.666666666666671" height="20.333333333333332"/>
+                                                            <rect key="frame" x="0.0" y="0.0" width="63.666666666666664" height="17"/>
                                                             <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                                                             <nil key="textColor"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="12:16 AM" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="krw-3d-vsj">
-                                                            <rect key="frame" x="81.666666666666657" y="0.33333333333333393" width="264.33333333333337" height="19.666666666666664"/>
+                                                            <rect key="frame" x="69.666666666666657" y="0.66666666666666696" width="276.33333333333337" height="15.666666666666664"/>
                                                             <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
-                                                            <color key="textColor" systemColor="secondaryLabelColor" red="0.23529411764705882" green="0.23529411764705882" blue="0.2627450980392157" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
+                                                            <color key="textColor" systemColor="secondaryLabelColor"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
                                                         <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="Disclosure" translatesAutoresizingMaskIntoConstraints="NO" id="wgb-e1-RIb">
-                                                            <rect key="frame" x="352" y="3.3333333333333339" width="14" height="14.000000000000002"/>
+                                                            <rect key="frame" x="352" y="1.6666666666666661" width="14" height="14"/>
                                                             <constraints>
                                                                 <constraint firstAttribute="height" constant="14" id="9aU-Eh-pJm"/>
                                                                 <constraint firstAttribute="width" constant="14" id="ROJ-mF-KxD"/>
@@ -278,16 +299,16 @@
                                                     </constraints>
                                                 </stackView>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="751" text="Fwd: Jane's independent studies" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3Gm-mS-pbN">
-                                                    <rect key="frame" x="0.0" y="22.333333333333332" width="224.33333333333334" height="17.999999999999996"/>
+                                                    <rect key="frame" x="0.0" y="19" width="186" height="14.333333333333336"/>
                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="751" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pNK-Lz-z8w">
-                                                    <rect key="frame" x="0.0" y="42.333333333333336" width="360" height="38.000000000000007"/>
+                                                    <rect key="frame" x="0.0" y="35.333333333333336" width="364.33333333333331" height="30.333333333333336"/>
                                                     <string key="text">Sra. Mendez - Thank you so MUCH for this.  We know you do not have to do this and we are so grateful to you.  Please let us know if there's anything else we can do.</string>
                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
-                                                    <color key="textColor" systemColor="secondaryLabelColor" red="0.23529411764705882" green="0.23529411764705882" blue="0.2627450980392157" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <color key="textColor" systemColor="secondaryLabelColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                             </subviews>
@@ -297,7 +318,7 @@
                                         </stackView>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Rbe-ZQ-d8Z">
                                             <rect key="frame" x="32" y="97.666666666666671" width="382" height="0.3333333333333286"/>
-                                            <color key="backgroundColor" systemColor="separatorColor" red="0.23529411764705882" green="0.23529411764705882" blue="0.2627450980392157" alpha="0.28999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
+                                            <color key="backgroundColor" systemColor="separatorColor"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="0.5" id="ED0-wW-eNH"/>
                                             </constraints>
@@ -345,12 +366,138 @@
             </objects>
             <point key="canvasLocation" x="1615.9420289855075" y="606.52173913043487"/>
         </scene>
+        <!--Inbox-->
+        <scene sceneID="rc3-hV-i2y">
+            <objects>
+                <collectionViewController title="Inbox" id="L77-gb-JYx" customClass="CustomMailCollectionViewController" customModule="MailExample" customModuleProvider="target" sceneMemberID="viewController">
+                    <collectionView key="view" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" id="Z54-Hj-JGR">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="736"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="0.0" minimumInteritemSpacing="0.0" sectionInsetReference="safeArea" id="ROq-2Y-oLX">
+                            <size key="itemSize" width="414" height="98"/>
+                            <size key="headerReferenceSize" width="0.0" height="0.0"/>
+                            <size key="footerReferenceSize" width="0.0" height="0.0"/>
+                            <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
+                        </collectionViewFlowLayout>
+                        <cells>
+                            <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" reuseIdentifier="MailCell" id="XTQ-LR-Mu2" customClass="CustomMailCollectionViewCell" customModule="MailExample" customModuleProvider="target">
+                                <rect key="frame" x="0.0" y="0.0" width="414" height="98"/>
+                                <autoresizingMask key="autoresizingMask"/>
+                                <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO">
+                                    <rect key="frame" x="0.0" y="0.0" width="414" height="98"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                    <subviews>
+                                        <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacing="2" translatesAutoresizingMaskIntoConstraints="NO" id="kkH-5a-UZn">
+                                            <rect key="frame" x="32" y="8" width="366" height="65.666666666666671"/>
+                                            <subviews>
+                                                <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="G2m-tl-MkG">
+                                                    <rect key="frame" x="0.0" y="0.0" width="366" height="17"/>
+                                                    <subviews>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="252" verticalHuggingPriority="251" text="John Doe" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="N2m-dk-ObV">
+                                                            <rect key="frame" x="0.0" y="0.0" width="63.666666666666664" height="17"/>
+                                                            <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
+                                                            <nil key="textColor"/>
+                                                            <nil key="highlightedColor"/>
+                                                        </label>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="12:16 AM" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="URd-cI-enm">
+                                                            <rect key="frame" x="69.666666666666657" y="0.66666666666666696" width="276.33333333333337" height="15.666666666666664"/>
+                                                            <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
+                                                            <color key="textColor" systemColor="secondaryLabelColor"/>
+                                                            <nil key="highlightedColor"/>
+                                                        </label>
+                                                        <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="Disclosure" translatesAutoresizingMaskIntoConstraints="NO" id="Mvo-Hb-RsO">
+                                                            <rect key="frame" x="352" y="1.6666666666666661" width="14" height="14"/>
+                                                            <constraints>
+                                                                <constraint firstAttribute="width" constant="14" id="BSH-CH-h4O"/>
+                                                                <constraint firstAttribute="height" constant="14" id="Vqd-xf-sKI"/>
+                                                            </constraints>
+                                                        </imageView>
+                                                    </subviews>
+                                                    <constraints>
+                                                        <constraint firstItem="URd-cI-enm" firstAttribute="baseline" secondItem="N2m-dk-ObV" secondAttribute="baseline" id="vd6-Aq-oUi"/>
+                                                    </constraints>
+                                                </stackView>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="751" text="Fwd: Jane's independent studies" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="It5-IQ-RDJ">
+                                                    <rect key="frame" x="0.0" y="19" width="186" height="14.333333333333336"/>
+                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="751" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jaG-5e-1Rv">
+                                                    <rect key="frame" x="0.0" y="35.333333333333336" width="364.33333333333331" height="30.333333333333336"/>
+                                                    <string key="text">Sra. Mendez - Thank you so MUCH for this.  We know you do not have to do this and we are so grateful to you.  Please let us know if there's anything else we can do.</string>
+                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
+                                                    <color key="textColor" systemColor="secondaryLabelColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstItem="G2m-tl-MkG" firstAttribute="width" secondItem="kkH-5a-UZn" secondAttribute="width" id="EHu-oz-TbN"/>
+                                            </constraints>
+                                        </stackView>
+                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="HCf-Go-0XR">
+                                            <rect key="frame" x="32" y="97.666666666666671" width="382" height="0.3333333333333286"/>
+                                            <color key="backgroundColor" systemColor="separatorColor"/>
+                                            <constraints>
+                                                <constraint firstAttribute="height" constant="0.5" id="nxl-Lh-5Mt"/>
+                                            </constraints>
+                                        </view>
+                                    </subviews>
+                                </view>
+                                <constraints>
+                                    <constraint firstItem="kkH-5a-UZn" firstAttribute="leading" secondItem="XTQ-LR-Mu2" secondAttribute="leadingMargin" constant="24" id="4xF-1s-Cj2"/>
+                                    <constraint firstAttribute="trailingMargin" secondItem="kkH-5a-UZn" secondAttribute="trailing" constant="8" id="Egl-PN-k4p"/>
+                                    <constraint firstItem="HCf-Go-0XR" firstAttribute="leading" secondItem="XTQ-LR-Mu2" secondAttribute="leadingMargin" constant="24" id="HP3-QX-zFk"/>
+                                    <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="kkH-5a-UZn" secondAttribute="bottom" id="iNq-Iw-Jv8"/>
+                                    <constraint firstAttribute="bottom" secondItem="HCf-Go-0XR" secondAttribute="bottom" id="mpR-cd-arr"/>
+                                    <constraint firstItem="kkH-5a-UZn" firstAttribute="top" secondItem="XTQ-LR-Mu2" secondAttribute="topMargin" id="tHN-3S-hn6"/>
+                                    <constraint firstAttribute="trailing" secondItem="HCf-Go-0XR" secondAttribute="trailing" id="ztY-2a-Ydb"/>
+                                </constraints>
+                                <connections>
+                                    <outlet property="bodyLabel" destination="jaG-5e-1Rv" id="HPJ-9c-Ijd"/>
+                                    <outlet property="dateLabel" destination="URd-cI-enm" id="TDg-Pt-Xo0"/>
+                                    <outlet property="fromLabel" destination="N2m-dk-ObV" id="2VD-L5-ofI"/>
+                                    <outlet property="subjectLabel" destination="It5-IQ-RDJ" id="LaK-x9-5sf"/>
+                                </connections>
+                            </collectionViewCell>
+                        </cells>
+                        <connections>
+                            <outlet property="dataSource" destination="L77-gb-JYx" id="ssP-cd-OWG"/>
+                            <outlet property="delegate" destination="L77-gb-JYx" id="fjf-HK-VbO"/>
+                        </connections>
+                    </collectionView>
+                    <toolbarItems>
+                        <barButtonItem image="MoreOutline" id="WnN-DX-cwA">
+                            <connections>
+                                <action selector="moreTapped:" destination="L77-gb-JYx" id="Clh-B4-FF7"/>
+                            </connections>
+                        </barButtonItem>
+                        <barButtonItem style="plain" systemItem="flexibleSpace" id="Q9n-hU-gmm"/>
+                        <barButtonItem systemItem="compose" id="Gx8-VD-1mb"/>
+                    </toolbarItems>
+                    <navigationItem key="navigationItem" id="llX-qr-8kR"/>
+                    <simulatedToolbarMetrics key="simulatedBottomBarMetrics"/>
+                </collectionViewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="AVl-l5-8oP" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="822" y="892"/>
+        </scene>
     </scenes>
-    <resources>
-        <image name="Disclosure" width="14" height="14"/>
-        <image name="MoreOutline" width="23" height="23"/>
-    </resources>
     <inferredMetricsTieBreakers>
         <segue reference="Eug-d6-ZUM"/>
     </inferredMetricsTieBreakers>
+    <resources>
+        <image name="Disclosure" width="14" height="14"/>
+        <image name="MoreOutline" width="23" height="23"/>
+        <systemColor name="secondaryLabelColor">
+            <color red="0.23529411764705882" green="0.23529411764705882" blue="0.2627450980392157" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="separatorColor">
+            <color red="0.23529411764705882" green="0.23529411764705882" blue="0.2627450980392157" alpha="0.28999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/Example/MailExample/Main.storyboard
+++ b/Example/MailExample/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="LX8-Wu-PZs">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="LX8-Wu-PZs">
     <device id="retina5_5" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -170,7 +170,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <sections>
-                            <tableViewSection id="iR0-38-MTh">
+                            <tableViewSection headerTitle="Basic examples" id="iR0-38-MTh">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="rW1-t9-nrA" style="IBUITableViewCellStyleDefault" id="Kgd-u6-cy7">
                                         <rect key="frame" x="0.0" y="44.666666030883789" width="414" height="44"/>
@@ -230,6 +230,30 @@
                                         </tableViewCellContentView>
                                         <connections>
                                             <segue destination="L77-gb-JYx" kind="show" id="HlL-CN-ByY"/>
+                                        </connections>
+                                    </tableViewCell>
+                                </cells>
+                            </tableViewSection>
+                            <tableViewSection headerTitle="Exotic examples" id="8p9-CA-7lH">
+                                <cells>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="Fhl-FV-g7e" style="IBUITableViewCellStyleDefault" id="T9v-M6-dDN">
+                                        <rect key="frame" x="0.0" y="243.99999809265137" width="414" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="T9v-M6-dDN" id="5sX-v0-Bmq">
+                                            <rect key="frame" x="0.0" y="0.0" width="385.33333333333331" height="44"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Lists in pages controller" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Fhl-FV-g7e">
+                                                    <rect key="frame" x="20" y="0.0" width="357.33333333333331" height="44"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                        <connections>
+                                            <segue destination="Fwa-tU-csS" kind="show" id="8iB-Kb-enZ"/>
                                         </connections>
                                     </tableViewCell>
                                 </cells>
@@ -364,7 +388,26 @@
                 </collectionViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="zfN-Wd-L2x" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1615.9420289855075" y="606.52173913043487"/>
+            <point key="canvasLocation" x="1690" y="543"/>
+        </scene>
+        <!--List Pages View Controller-->
+        <scene sceneID="5xC-sh-fNL">
+            <objects>
+                <viewController id="Fwa-tU-csS" customClass="ListPagesViewController" customModule="MailExample" customModuleProvider="target" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="cSI-OU-mye"/>
+                        <viewControllerLayoutGuide type="bottom" id="3fp-jo-f5H"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="SLN-MJ-u01">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="736"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
+                    <navigationItem key="navigationItem" id="UDo-Wv-mgZ"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="QSr-NV-5mq" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="2540" y="1162"/>
         </scene>
         <!--Inbox-->
         <scene sceneID="rc3-hV-i2y">

--- a/Example/MailExample/RoundedCornersActionContentView.swift
+++ b/Example/MailExample/RoundedCornersActionContentView.swift
@@ -1,0 +1,104 @@
+//
+//  RoundedCornersActionContentView.swift
+//  MailExample
+//
+//  Created by Ilia Sedov on 05.05.2022.
+//
+
+import UIKit
+import SwipeCellKit
+
+class RoundedCornersActionContentView: ActionContentView {
+    private let bgView = UIView()
+    private let titleLabel = UILabel()
+    private let imageView = UIImageView()
+    private var action: SwipeAction?
+    private var highlightedBackgroundColor: UIColor?
+    private var highlightedTextColor: UIColor?
+
+    override func setupView(with action: SwipeAction) {
+        self.action = action
+        highlightedBackgroundColor = action.highlightedBackgroundColor ?? action.backgroundColor?.getHighlightedColor()
+        highlightedTextColor = action.highlightedTextColor ?? .white.getHighlightedColor()
+
+        buildView()
+
+        bgView.backgroundColor = action.backgroundColor
+        titleLabel.font = action.font ?? UIFont.systemFont(ofSize: 15, weight: UIFont.Weight.medium)
+        titleLabel.textColor = action.textColor ?? .white
+        titleLabel.text = action.title
+        imageView.image = action.image
+    }
+
+    private func buildView() {
+        bgView.layer.cornerRadius = 12.0
+        bgView.layer.cornerCurve = .continuous
+        addSubview(bgView)
+        bgView.translatesAutoresizingMaskIntoConstraints = false
+
+
+        titleLabel.textAlignment = .center
+        titleLabel.lineBreakMode = .byTruncatingTail
+        titleLabel.adjustsFontSizeToFitWidth = true
+        titleLabel.minimumScaleFactor = 0.8
+        titleLabel.numberOfLines = 1
+        titleLabel.setContentHuggingPriority(.required, for: .vertical)
+
+        imageView.tintColor = .white
+
+        let stack = UIStackView(arrangedSubviews: [imageView, titleLabel])
+        stack.axis = .vertical
+        stack.alignment = .center
+        stack.spacing = 4
+        stack.distribution = .equalCentering
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(stack)
+
+        NSLayoutConstraint.activate([
+            bgView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 2),
+            bgView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -2),
+            bgView.topAnchor.constraint(equalTo: topAnchor, constant: 2),
+            bgView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -2),
+
+            stack.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 8),
+            stack.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -8),
+            stack.centerYAnchor.constraint(equalTo: centerYAnchor)
+        ])
+    }
+
+    override func preferredWidth(maximum: CGFloat) -> CGFloat {
+        let width = maximum > 0 ? maximum : CGFloat.greatestFiniteMagnitude
+        let textWidth = titleBoundingRect(with: CGSize(width: width, height: CGFloat.greatestFiniteMagnitude)).width
+        let imageWidth = imageView.image?.size.width ?? 0
+
+        let leftInset: CGFloat = 4
+        let rightInset: CGFloat = 4
+
+        return min(width, max(textWidth, imageWidth) + leftInset + rightInset)
+    }
+
+    private func titleBoundingRect(with size: CGSize) -> CGRect {
+        guard let title = titleLabel.text else { return .zero }
+
+        return title.boundingRect(
+            with: size,
+            options: [.usesLineFragmentOrigin],
+            attributes: [NSAttributedString.Key.font: titleLabel.font as Any],
+            context: nil
+        ).integral
+    }
+
+    override var isHighlighted: Bool {
+        didSet {
+            guard let action = action else { return }
+
+            if isHighlighted {
+                bgView.backgroundColor = highlightedBackgroundColor
+                titleLabel.textColor = highlightedTextColor
+            } else {
+                bgView.backgroundColor = action.backgroundColor
+                titleLabel.textColor = action.textColor ?? .white
+            }
+        }
+    }
+}

--- a/Example/MailExample/RoundedCornersActionContentView.swift
+++ b/Example/MailExample/RoundedCornersActionContentView.swift
@@ -33,6 +33,8 @@ class RoundedCornersActionContentView: ActionContentView {
     private func buildView() {
         bgView.layer.cornerRadius = 12.0
         bgView.layer.cornerCurve = .continuous
+        layer.cornerRadius = 12.0
+        layer.cornerCurve = .continuous
         addSubview(bgView)
         bgView.translatesAutoresizingMaskIntoConstraints = false
 
@@ -57,8 +59,8 @@ class RoundedCornersActionContentView: ActionContentView {
         NSLayoutConstraint.activate([
             bgView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 2),
             bgView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -2),
-            bgView.topAnchor.constraint(equalTo: topAnchor, constant: 2),
-            bgView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -2),
+            bgView.topAnchor.constraint(equalTo: topAnchor),
+            bgView.bottomAnchor.constraint(equalTo: bottomAnchor),
 
             stack.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 8),
             stack.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -8),

--- a/Example/MailExample/RoundedCornersActionContentView.swift
+++ b/Example/MailExample/RoundedCornersActionContentView.swift
@@ -9,31 +9,57 @@ import UIKit
 import SwipeCellKit
 
 class RoundedCornersActionContentView: ActionContentView {
+    private enum Layout {
+        static let circleDiameter: CGFloat = 46
+        static let horizontalInset: CGFloat = 2
+        static let collapsedWidth = circleDiameter + horizontalInset * 2
+    }
+
     private let bgView = UIView()
+    private let iconContainerView = UIView()
     private let titleLabel = UILabel()
+    private let titleContainerView = UIView()
     private let imageView = UIImageView()
+    private var backgroundWidthConstraint: NSLayoutConstraint?
     private var action: SwipeAction?
+    private var usesStretchableCircularBackground = false
+    private var normalBackgroundColor: UIColor?
+    private var normalTitleColor: UIColor?
     private var highlightedBackgroundColor: UIColor?
     private var highlightedTextColor: UIColor?
 
     override func setupView(with action: SwipeAction) {
         self.action = action
-        highlightedBackgroundColor = action.highlightedBackgroundColor ?? action.backgroundColor?.getHighlightedColor()
-        highlightedTextColor = action.highlightedTextColor ?? .white.getHighlightedColor()
+        usesStretchableCircularBackground = action.backgroundColor == .clear
+        normalBackgroundColor = usesStretchableCircularBackground ? action.textColor : action.backgroundColor
+        normalTitleColor = action.textColor ?? .white
+        highlightedBackgroundColor = action.highlightedBackgroundColor ?? normalBackgroundColor?.getHighlightedColor()
+        highlightedTextColor = action.highlightedTextColor ?? normalTitleColor?.getHighlightedColor()
 
         buildView()
 
-        bgView.backgroundColor = action.backgroundColor
+        bgView.backgroundColor = normalBackgroundColor
         titleLabel.font = action.font ?? UIFont.systemFont(ofSize: 15, weight: UIFont.Weight.medium)
-        titleLabel.textColor = action.textColor ?? .white
+        titleLabel.textColor = normalTitleColor
         titleLabel.text = action.title
-        imageView.image = action.image
+        imageView.image = usesStretchableCircularBackground
+            ? action.image?.withRenderingMode(.alwaysTemplate)
+            : action.image
+        imageView.tintColor = .white
+
+        iconContainerView.isHidden = usesStretchableCircularBackground && imageView.image == nil
+        if usesStretchableCircularBackground {
+            titleContainerView.isHidden = titleLabel.text == nil
+        } else {
+            titleLabel.isHidden = titleLabel.text == nil
+        }
     }
 
     private func buildView() {
-        bgView.layer.cornerRadius = 12.0
+        bgView.layer.cornerRadius = usesStretchableCircularBackground ? Layout.circleDiameter / 2 : 12
         bgView.layer.cornerCurve = .continuous
-        layer.cornerRadius = 12.0
+        bgView.clipsToBounds = true
+        layer.cornerRadius = bgView.layer.cornerRadius
         layer.cornerCurve = .continuous
         addSubview(bgView)
         bgView.translatesAutoresizingMaskIntoConstraints = false
@@ -46,8 +72,54 @@ class RoundedCornersActionContentView: ActionContentView {
         titleLabel.numberOfLines = 1
         titleLabel.setContentHuggingPriority(.required, for: .vertical)
 
-        imageView.tintColor = .white
+        if usesStretchableCircularBackground {
+            buildStretchableCircularLayout()
+        } else {
+            buildBackgroundColorLayout()
+        }
+    }
 
+    private func buildStretchableCircularLayout() {
+        iconContainerView.addSubview(bgView)
+        bgView.translatesAutoresizingMaskIntoConstraints = false
+        bgView.addSubview(imageView)
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+
+        titleContainerView.addSubview(titleLabel)
+        titleLabel.translatesAutoresizingMaskIntoConstraints = false
+
+        let stack = UIStackView(arrangedSubviews: [iconContainerView, titleContainerView])
+        stack.axis = .vertical
+        stack.alignment = .fill
+        stack.spacing = 4
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(stack)
+
+        let backgroundWidthConstraint = bgView.widthAnchor.constraint(equalToConstant: Layout.circleDiameter)
+        self.backgroundWidthConstraint = backgroundWidthConstraint
+
+        NSLayoutConstraint.activate([
+            stack.leadingAnchor.constraint(equalTo: leadingAnchor),
+            stack.trailingAnchor.constraint(equalTo: trailingAnchor),
+            stack.centerYAnchor.constraint(equalTo: centerYAnchor),
+
+            iconContainerView.heightAnchor.constraint(equalToConstant: Layout.circleDiameter),
+            bgView.centerXAnchor.constraint(equalTo: iconContainerView.centerXAnchor),
+            bgView.centerYAnchor.constraint(equalTo: iconContainerView.centerYAnchor),
+            bgView.heightAnchor.constraint(equalToConstant: Layout.circleDiameter),
+            backgroundWidthConstraint,
+            imageView.centerXAnchor.constraint(equalTo: bgView.centerXAnchor),
+            imageView.centerYAnchor.constraint(equalTo: bgView.centerYAnchor),
+
+            titleLabel.centerXAnchor.constraint(equalTo: titleContainerView.centerXAnchor),
+            titleLabel.leadingAnchor.constraint(greaterThanOrEqualTo: titleContainerView.leadingAnchor),
+            titleLabel.trailingAnchor.constraint(lessThanOrEqualTo: titleContainerView.trailingAnchor),
+            titleLabel.topAnchor.constraint(equalTo: titleContainerView.topAnchor),
+            titleLabel.bottomAnchor.constraint(equalTo: titleContainerView.bottomAnchor)
+        ])
+    }
+
+    private func buildBackgroundColorLayout() {
         let stack = UIStackView(arrangedSubviews: [imageView, titleLabel])
         stack.axis = .vertical
         stack.alignment = .center
@@ -57,8 +129,8 @@ class RoundedCornersActionContentView: ActionContentView {
         addSubview(stack)
 
         NSLayoutConstraint.activate([
-            bgView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 2),
-            bgView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -2),
+            bgView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: Layout.horizontalInset),
+            bgView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -Layout.horizontalInset),
             bgView.topAnchor.constraint(equalTo: topAnchor),
             bgView.bottomAnchor.constraint(equalTo: bottomAnchor),
 
@@ -69,6 +141,14 @@ class RoundedCornersActionContentView: ActionContentView {
     }
 
     override func preferredWidth(maximum: CGFloat) -> CGFloat {
+        if usesStretchableCircularBackground {
+            let width = maximum > 0 ? maximum : CGFloat.greatestFiniteMagnitude
+            let titleWidth = titleBoundingRect(
+                with: CGSize(width: width, height: CGFloat.greatestFiniteMagnitude)
+            ).width + 8
+            return min(width, max(Layout.collapsedWidth, titleWidth))
+        }
+
         let width = maximum > 0 ? maximum : CGFloat.greatestFiniteMagnitude
         let textWidth = titleBoundingRect(with: CGSize(width: width, height: CGFloat.greatestFiniteMagnitude)).width
         let imageWidth = imageView.image?.size.width ?? 0
@@ -77,6 +157,30 @@ class RoundedCornersActionContentView: ActionContentView {
         let rightInset: CGFloat = 4
 
         return min(width, max(textWidth, imageWidth) + leftInset + rightInset)
+    }
+
+    override func didChangeExpansion(_ context: SwipeActionExpansionContext) {
+        guard usesStretchableCircularBackground else { return }
+
+        let additionalWidth = max(0, context.additionalWidth)
+        let regularBackgroundWidth = max(
+            Layout.circleDiameter,
+            context.regularWidth - Layout.horizontalInset * 2
+        )
+        let collapsedGap = regularBackgroundWidth - Layout.circleDiameter
+        let catchUpProgress = collapsedGap > 0
+            ? min(additionalWidth / collapsedGap, 1)
+            : 1
+        let maximumBackgroundWidth = max(
+            Layout.circleDiameter,
+            context.currentWidth - Layout.horizontalInset * 2
+        )
+
+        backgroundWidthConstraint?.constant = min(
+            maximumBackgroundWidth,
+            Layout.circleDiameter + additionalWidth + collapsedGap * catchUpProgress
+        )
+        setNeedsLayout()
     }
 
     private func titleBoundingRect(with size: CGSize) -> CGRect {
@@ -92,14 +196,14 @@ class RoundedCornersActionContentView: ActionContentView {
 
     override var isHighlighted: Bool {
         didSet {
-            guard let action = action else { return }
+            guard action != nil else { return }
 
             if isHighlighted {
                 bgView.backgroundColor = highlightedBackgroundColor
                 titleLabel.textColor = highlightedTextColor
             } else {
-                bgView.backgroundColor = action.backgroundColor
-                titleLabel.textColor = action.textColor ?? .white
+                bgView.backgroundColor = normalBackgroundColor
+                titleLabel.textColor = normalTitleColor
             }
         }
     }

--- a/Example/MailExample/ScalarSpring.swift
+++ b/Example/MailExample/ScalarSpring.swift
@@ -1,0 +1,93 @@
+//
+//  ScalarSpring.swift
+//  MailExample
+//
+
+import Foundation
+
+struct ScalarSpring {
+    private enum Constants {
+        static let integrationStep: CGFloat = 1.0 / 240.0
+        static let maximumElapsedTime: CGFloat = 1.0 / 30.0
+        static let valueTolerance: CGFloat = 0.0005
+        static let velocityTolerance: CGFloat = 0.005
+    }
+
+    let mass: CGFloat
+    let stiffness: CGFloat
+    let maximumVelocity: CGFloat
+    let valueRange: ClosedRange<CGFloat>
+
+    private(set) var value: CGFloat
+    var target: CGFloat
+    var velocity: CGFloat = 0
+
+    var criticalDamping: CGFloat {
+        2 * sqrt(stiffness * mass)
+    }
+
+    var isAtRest: Bool {
+        abs(value - target) <= Constants.valueTolerance
+            && abs(velocity) <= Constants.velocityTolerance
+    }
+
+    init(
+        value: CGFloat,
+        mass: CGFloat,
+        stiffness: CGFloat,
+        maximumVelocity: CGFloat,
+        valueRange: ClosedRange<CGFloat>
+    ) {
+        self.mass = mass
+        self.stiffness = stiffness
+        self.maximumVelocity = maximumVelocity
+        self.valueRange = valueRange
+        self.value = value
+        self.target = value
+    }
+
+    mutating func reset(to value: CGFloat) {
+        self.value = value
+        target = value
+        velocity = 0
+    }
+
+    mutating func finish() {
+        value = target
+        velocity = 0
+    }
+
+    mutating func advance(by elapsedTime: CGFloat, damping: CGFloat) {
+        var remainingTime = min(elapsedTime, Constants.maximumElapsedTime)
+
+        while remainingTime > 0 {
+            let time = min(remainingTime, Constants.integrationStep)
+            advanceOneStep(by: time, damping: damping)
+            remainingTime -= time
+        }
+    }
+
+    private mutating func advanceOneStep(by time: CGFloat, damping: CGFloat) {
+        let springForce = -stiffness * (value - target)
+        let dampingForce = -damping * velocity
+        let acceleration = (springForce + dampingForce) / mass
+
+        velocity = clamped(
+            velocity + acceleration * time,
+            to: -maximumVelocity...maximumVelocity
+        )
+        value += velocity * time
+
+        if value <= valueRange.lowerBound {
+            value = valueRange.lowerBound
+            velocity = max(velocity, 0)
+        } else if value >= valueRange.upperBound {
+            value = valueRange.upperBound
+            velocity = min(velocity, 0)
+        }
+    }
+
+    private func clamped(_ value: CGFloat, to range: ClosedRange<CGFloat>) -> CGFloat {
+        min(max(value, range.lowerBound), range.upperBound)
+    }
+}

--- a/Example/MailExample/SpringRevealActionTransition.swift
+++ b/Example/MailExample/SpringRevealActionTransition.swift
@@ -1,0 +1,155 @@
+//
+//  SpringRevealActionTransition.swift
+//  MailExample
+//
+
+import QuartzCore
+import SwipeCellKit
+import UIKit
+
+/// A reveal transition whose opacity follows swipe progress while its scale
+/// continuously follows that progress using a spring.
+final class SpringRevealActionTransition: NSObject, SwipeActionTransitioning {
+    struct Configuration {
+        var revealStart: CGFloat = 0.2
+        var tension: CGFloat = 573
+        var friction: CGFloat = 26
+        var mass: CGFloat = 1
+        var hiddenScale: CGFloat = 0.001
+        var maximumScale: CGFloat = 1.06
+        var maximumVelocity: CGFloat = 8
+    }
+
+    private let configuration: Configuration
+    private let isReduceMotionEnabled: () -> Bool
+
+    private weak var button: UIView?
+    private var displayLink: CADisplayLink?
+    private var previousTimestamp: CFTimeInterval?
+    private var spring: ScalarSpring
+    private var isInteractive = false
+
+    init(
+        configuration: Configuration = Configuration(),
+        isReduceMotionEnabled: @escaping () -> Bool = { UIAccessibility.isReduceMotionEnabled }
+    ) {
+        var configuration = configuration
+        configuration.revealStart = min(max(configuration.revealStart, 0), 0.999)
+        configuration.tension = max(configuration.tension, 0.001)
+        configuration.friction = max(configuration.friction, 0)
+        configuration.mass = max(configuration.mass, 0.001)
+        configuration.hiddenScale = min(max(configuration.hiddenScale, 0.0001), 1)
+        configuration.maximumScale = max(configuration.maximumScale, 1)
+        configuration.maximumVelocity = max(configuration.maximumVelocity, 0.001)
+
+        self.configuration = configuration
+        self.isReduceMotionEnabled = isReduceMotionEnabled
+        self.spring = ScalarSpring(
+            value: configuration.hiddenScale,
+            mass: configuration.mass,
+            stiffness: configuration.tension,
+            maximumVelocity: configuration.maximumVelocity,
+            valueRange: configuration.hiddenScale...configuration.maximumScale
+        )
+        super.init()
+    }
+
+    deinit {
+        stopSpring()
+    }
+
+    func prepareTransition(with context: SwipeActionTransitioningContext) {
+        stopSpring()
+        button = context.button
+        isInteractive = false
+        spring.reset(to: configuration.hiddenScale)
+
+        context.button.alpha = 0
+        context.button.transform = isReduceMotionEnabled()
+            ? .identity
+            : transform(for: spring.value)
+    }
+
+    func didTransition(with context: SwipeActionTransitioningContext) {
+        button = context.button
+
+        let progress = normalizedProgress(for: context.newPercentVisible)
+
+        guard !isReduceMotionEnabled() else {
+            stopSpring()
+            context.button.alpha = progress
+            context.button.transform = .identity
+            return
+        }
+
+        spring.target = scale(for: progress)
+        isInteractive = context.isInteractive
+
+        if !isInteractive {
+            spring.velocity = 0
+        }
+
+        startSpringIfNeeded()
+    }
+
+    private func normalizedProgress(for percentVisible: CGFloat) -> CGFloat {
+        let progress = (percentVisible - configuration.revealStart)
+            / (1 - configuration.revealStart)
+        return min(max(progress, 0), 1)
+    }
+
+    private func scale(for progress: CGFloat) -> CGFloat {
+        configuration.hiddenScale
+            + (1 - configuration.hiddenScale) * progress
+    }
+
+    private func progress(for scale: CGFloat) -> CGFloat {
+        let progress = (scale - configuration.hiddenScale)
+            / (1 - configuration.hiddenScale)
+        return min(max(progress, 0), 1)
+    }
+
+    private func transform(for scale: CGFloat) -> CGAffineTransform {
+        CGAffineTransform(scaleX: scale, y: scale)
+    }
+
+    private func startSpringIfNeeded() {
+        guard displayLink == nil, !spring.isAtRest else { return }
+
+        previousTimestamp = nil
+        let displayLink = CADisplayLink(target: self, selector: #selector(updateSpring(_:)))
+        displayLink.add(to: .main, forMode: .common)
+        self.displayLink = displayLink
+    }
+
+    private func stopSpring() {
+        displayLink?.invalidate()
+        displayLink = nil
+        previousTimestamp = nil
+    }
+
+    @objc private func updateSpring(_ displayLink: CADisplayLink) {
+        guard let button = button else {
+            stopSpring()
+            return
+        }
+
+        let elapsed = previousTimestamp.map {
+            CGFloat(displayLink.timestamp - $0)
+        } ?? CGFloat(displayLink.duration)
+        previousTimestamp = displayLink.timestamp
+
+        let damping = isInteractive
+            ? configuration.friction
+            : spring.criticalDamping
+        spring.advance(by: elapsed, damping: damping)
+
+        if spring.isAtRest {
+            spring.finish()
+            stopSpring()
+        }
+
+        button.transform = transform(for: spring.value)
+        button.alpha = progress(for: spring.value)
+    }
+}

--- a/Example/MailExample/UIColor+Highlighted.swift
+++ b/Example/MailExample/UIColor+Highlighted.swift
@@ -1,0 +1,31 @@
+//
+//  UIColor+Highlighted.swift
+//  MailExample
+//
+//  Created by Ilia Sedov on 05.05.2022.
+//
+
+import UIKit
+
+extension UIColor {
+    func getHighlightedColor() -> UIColor {
+        var hue: CGFloat = 0.0
+        var saturation: CGFloat = 0.0
+        var brightness: CGFloat = 0.0
+        var alpha: CGFloat = 0.0
+        if getHue(
+            &hue,
+            saturation: &saturation,
+            brightness: &brightness,
+            alpha: &alpha
+        ) {
+            return UIColor(
+                hue: hue,
+                saturation: saturation,
+                brightness: brightness - 0.1,
+                alpha: alpha
+            )
+        }
+        return withAlphaComponent(0.8)
+    }
+}

--- a/Example/MailExampleUITests/MailExampleUITests.swift
+++ b/Example/MailExampleUITests/MailExampleUITests.swift
@@ -1,0 +1,60 @@
+//
+//  MailExampleUITests.swift
+//  MailExampleUITests
+//
+//  Created by Ilia Sedov on 18.05.2022.
+//
+
+import XCTest
+
+class MailExampleUITests: XCTestCase {
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    func testActionTappableFromUITest() throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        app.tables.cells.staticTexts["Custom Content Action Collection"].tap()
+
+        let toDeleteCellText = "Hello, The gerbils at the Pragmatic Bookstore have just finished hand-crafting your eBook of Swift Style. It's available for download at the following URL:"
+        let cell = findCell(label: toDeleteCellText, in: app)
+        cell.swipeLeft(velocity: XCUIGestureVelocity.default)
+
+        app.buttons["Trash"].tap()
+
+        let removed = NSPredicate(format: "exists == 0")
+        expectation(for: removed, evaluatedWith: cell, handler: nil)
+        waitForExpectations(timeout: 1, handler: nil)
+    }
+
+    func testActionCustomAccessibilityLabel() {
+        let app = XCUIApplication()
+        app.launch()
+
+        app.tables.cells.staticTexts["Custom Content Action Collection"].tap()
+
+        let toDeleteCellText = "Hello, The gerbils at the Pragmatic Bookstore have just finished hand-crafting your eBook of Swift Style. It's available for download at the following URL:"
+        let cell = findCell(label: toDeleteCellText, in: app)
+        cell.swipeLeft(velocity: XCUIGestureVelocity.default)
+
+        let flagButton = app.buttons["Accessible Button"]
+        flagButton.tap()
+
+        let actionsClosed = NSPredicate(format: "exists == 0")
+        expectation(for: actionsClosed, evaluatedWith: flagButton, handler: nil)
+        waitForExpectations(timeout: 1, handler: nil)
+
+    }
+
+
+    private func findCell(label: String, in app: XCUIApplication) -> XCUIElement {
+        app.collectionViews
+            .cells
+            .staticTexts
+            .containing(.init(format: "label CONTAINS %@", label))
+            .firstMatch
+    }
+}

--- a/Example/MailExampleUITests/MailExampleUITests.swift
+++ b/Example/MailExampleUITests/MailExampleUITests.swift
@@ -27,7 +27,7 @@ class MailExampleUITests: XCTestCase {
 
         let removed = NSPredicate(format: "exists == 0")
         expectation(for: removed, evaluatedWith: cell, handler: nil)
-        waitForExpectations(timeout: 1, handler: nil)
+        waitForExpectations(timeout: 1.5, handler: nil)
     }
 
     func testActionCustomAccessibilityLabel() {
@@ -45,7 +45,7 @@ class MailExampleUITests: XCTestCase {
 
         let actionsClosed = NSPredicate(format: "exists == 0")
         expectation(for: actionsClosed, evaluatedWith: flagButton, handler: nil)
-        waitForExpectations(timeout: 1, handler: nil)
+        waitForExpectations(timeout: 1.5, handler: nil)
 
     }
 

--- a/Guides/Advanced.md
+++ b/Guides/Advanced.md
@@ -15,6 +15,47 @@ The `ScaleTransition` type provides a static `default` configuration, but it can
 
 You can also easily provide your own completely custom transition behavior by adopting the `SwipeActionTransitioning` protocol. The supplied `SwipeActionTransitioningContext` to the delegate methods reflect the current swipe state as the gesture is performed.
 
+`prepareTransition(with:)` is called once after the action has a valid layout and before transition updates begin. Use it to establish the action's initial visual state, such as a zero scale or transparent appearance.
+
+`didTransition(with:)` is called as the action's visible percentage changes. The transition context provides both the previous and new visible percentages for that action. `isInteractive` is `true` while the gesture is being driven by the user's finger. A callback with `isInteractive == false` announces the final settling target; it is not called for every presentation frame of UIKit's settling animation. Custom transitions can scrub directly during interaction and start their own animation toward the supplied target during settling.
+
+## Customizing Action Widths
+
+The minimum and maximum action widths are configured through `SwipeOptions`:
+
+```swift
+options.minimumButtonWidth = 64
+options.maximumButtonWidth = 80
+```
+
+By default, all actions use the same width. The preferred widths of every action are measured and the widest result is shared:
+
+```swift
+options.buttonWidthMode = .equal
+```
+
+Set the mode to `.individual` when every action should use its own preferred width:
+
+```swift
+options.buttonWidthMode = .individual
+```
+
+In individual mode, SwipeCellKit asks each action's `ActionContentView` for `preferredWidth(maximum:)` and clamps each result to `minimumButtonWidth...maximumButtonWidth`. Reveal layouts, expansion, and gesture calculations use the sum of the resulting widths. Equal mode retains the framework's original shared-width resolution for backward compatibility.
+
+## Customizing the Release Threshold
+
+`activationThreshold` controls how far a gesture that starts with closed actions must travel before the actions open:
+
+```swift
+options.activationThreshold = .fractional(0.25)
+// or
+options.activationThreshold = .absolute(80)
+```
+
+A fractional threshold is relative to the cell width; an absolute threshold is measured in points. When this property is `nil`, SwipeCellKit preserves its default velocity-based opening behavior. Closing gestures always retain the default velocity-based behavior.
+
+This is separate from an expansion style's target and triggers: `activationThreshold` decides whether the actions open, while expansion configuration decides whether an expandable action commits.
+
 ## Customizing Expansion
 
 Expansion behavior is defined by the properties available in the `SwipeExpansionStyle` type: 
@@ -25,6 +66,21 @@ Expansion behavior is defined by the properties available in the `SwipeExpansion
 * `completionAnimation`: Specifies the expansion animation completion style.
 * `minimumTargetOverscroll`: Specifies the minimum amount of overscroll required if the configured target is less than the fully exposed action view.
 * `targetOverscrollElasticity`: The amount of elasticity applied when dragging past the expansion target.
+* `expandedActionLayout`: How the expanded action is positioned and sized.
+
+### Expanded Action Layout
+
+The default `.edgeAligned` layout preserves SwipeCellKit's original behavior. The expanded action keeps its regular width and moves toward the cell edge.
+
+Use `.fillAvailableSpace` to keep the primary action attached to the other actions and stretch it across the remaining revealed width:
+
+```swift
+var expansionStyle = SwipeExpansionStyle.destructive
+expansionStyle.expandedActionLayout = .fillAvailableSpace
+options.expansionStyle = expansionStyle
+```
+
+The action begins stretching after all actions have reached their regular widths. Use a custom `SwipeExpanding` implementation through `SwipeOptions.expansionDelegate` when the remaining actions should change alpha, scale, or another appearance property while expansion is armed.
 
 ### Target
 
@@ -117,6 +173,8 @@ options.expansionDelegate = ScaleAndAlphaExpansion.default
 The `ScaleAndAlphaExpansion` type provides a static `default` configuration, but it can also be instantiated with custom parameters to suit your needs.
 
 You can also provide your own completely custom expansion behavior by adopting the `SwipeExpanding` protocol. The protocol allows you to customize the animation timing parameters prior to initiating the (un)expansion animation, as well as customizing the action during (un)expansion.
+
+Custom action content can react to fill expansion by overriding `ActionContentView.didChangeExpansion(_:)`. The supplied `SwipeActionExpansionContext` contains the action's regular, current, and maximum widths, as well as the additional width beyond its regular size. This is useful when a fixed circular icon should gradually stretch into a pill only after the action itself begins expanding.
 
 ## Vertically Centered Swipe Actions for Tall Cells
 

--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "SwipeCellKit",
     platforms: [
-        .iOS(.v9),
+        .iOS(.v13),
     ],
     products: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.

--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "SwipeCellKit",
     platforms: [
-        .iOS(.v13),
+        .iOS(.13),
     ],
     products: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.

--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "SwipeCellKit",
     platforms: [
-        .iOS(.13),
+        .iOS("13.0"),
     ],
     products: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.
@@ -25,6 +25,11 @@ let package = Package(
             name: "SwipeCellKit",
             dependencies: [],
             path: "Source"
+        ),
+        .testTarget(
+            name: "SwipeCellKitTests",
+            dependencies: ["SwipeCellKit"],
+            path: "Tests"
         )
     ]
 )

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ A swipeable `UITableViewCell` or `UICollectionViewCell` with support for:
 * Customizable action button behavior during swipe
 * Animated expansion when dragging past threshold
 * Customizable expansion animations
+* Equal or individual action widths
+* Configurable release and expansion thresholds
 * Support for both `UITableView` and `UICollectionView`
 * Accessibility
 * Dark Mode
@@ -211,6 +213,24 @@ See [Customizing Transitions](https://github.com/SwipeCellKit/SwipeCellKit/blob/
 #### Transition Delegate
 
 Transition for a `SwipeAction` can be observered by setting a `SwipeActionTransitioning` on the `transitionDelegate` property. This allows you to observe what percentage is visible and access to the underlying `UIButton` for that `SwipeAction`. 
+
+### Action Widths and Release Threshold
+
+Actions use an equal width by default. They can instead preserve the preferred width reported by each action content view:
+
+```swift
+options.minimumButtonWidth = 64
+options.maximumButtonWidth = 80
+options.buttonWidthMode = .individual
+```
+
+You can also require a minimum drag distance before actions remain open when a gesture starts from the closed position:
+
+```swift
+options.activationThreshold = .fractional(0.25)
+```
+
+This release threshold is independent of the expansion threshold used to commit an expandable action. See the [Advanced Guide](Guides/Advanced.md) for details about widths, transition lifecycle, and fill expansion.
 
 ### Expansion
 

--- a/Source/ActionContentView.swift
+++ b/Source/ActionContentView.swift
@@ -1,0 +1,30 @@
+//
+//  ActionContentView.swift
+//  SwipeCellKit
+//
+//  Created by Ilia Sedov on 05.05.2022.
+//
+
+import UIKit
+
+open class ActionContentView: UIView {
+    public init(action: SwipeAction) {
+        super.init(frame: .zero)
+        setupView(with: action)
+    }
+
+    @available(*, unavailable)
+    required public init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    open func preferredWidth(maximum: CGFloat) -> CGFloat {
+        0.0
+    }
+
+    open func setupView(with action: SwipeAction) {
+
+    }
+
+    open var isHighlighted: Bool = false
+}

--- a/Source/ActionContentView.swift
+++ b/Source/ActionContentView.swift
@@ -7,6 +7,29 @@
 
 import UIKit
 
+/// Describes the expandable action's resolved widths during fill expansion.
+public struct SwipeActionExpansionContext {
+    /// The action's resolved width before expansion begins.
+    public let regularWidth: CGFloat
+
+    /// The action's current width.
+    public let currentWidth: CGFloat
+
+    /// The largest width currently available to the action.
+    public let maximumWidth: CGFloat
+
+    /// The width added beyond the action's regular width.
+    public var additionalWidth: CGFloat {
+        currentWidth - regularWidth
+    }
+
+    init(regularWidth: CGFloat, currentWidth: CGFloat, maximumWidth: CGFloat) {
+        self.regularWidth = regularWidth
+        self.currentWidth = currentWidth
+        self.maximumWidth = maximumWidth
+    }
+}
+
 open class ActionContentView: UIView {
     public init(action: SwipeAction) {
         super.init(frame: .zero)
@@ -18,13 +41,29 @@ open class ActionContentView: UIView {
         fatalError("init(coder:) has not been implemented")
     }
 
+    /// Returns the content's preferred regular action width, capped by `maximum`.
+    ///
+    /// Return a value larger than the configured minimum to allow this content to
+    /// influence action sizing. This value is also used independently for each
+    /// action when `SwipeOptions.buttonWidthMode` is `.individual`.
     open func preferredWidth(maximum: CGFloat) -> CGFloat {
         0.0
     }
 
-    open func setupView(with action: SwipeAction) {
+    /// Configures the content view for an action.
+    ///
+    /// This method is called from `init(action:)`. Subclasses should build their
+    /// view hierarchy and apply the action's appearance here.
+    open func setupView(with action: SwipeAction) {}
 
-    }
+    /// Notifies the content view that the expandable action's width changed.
+    ///
+    /// Override this method to implement content-specific expansion, such as
+    /// morphing a circle into a pill. The default implementation does nothing.
+    ///
+    /// - parameter context: The action's regular, current, and maximum widths.
+    open func didChangeExpansion(_ context: SwipeActionExpansionContext) {}
 
+    /// Whether the action content is currently highlighted.
     open var isHighlighted: Bool = false
 }

--- a/Source/DefaultActionContentView.swift
+++ b/Source/DefaultActionContentView.swift
@@ -1,0 +1,130 @@
+//
+//  DefaultActionContentView.swift
+//  SwipeCellKit
+//
+//  Created by Ilia Sedov on 05.05.2022.
+//
+
+import UIKit
+
+class DefaultActionContentView: ActionContentView {
+    var spacing: CGFloat = 8
+    var maximumImageHeight: CGFloat = 0
+    private let innerButton = InnerButtonContentView(frame: .zero)
+    private var highlightedBackgroundColor: UIColor?
+    private var normalBackgroundColor: UIColor?
+    private var verticalAlignment: SwipeVerticalAlignment = .centerFirstBaseline
+
+    override func setupView(with action: SwipeAction) {
+        normalBackgroundColor = action.backgroundColor
+        backgroundColor = action.backgroundColor
+        innerButton.contentHorizontalAlignment = .center
+
+        tintColor = action.textColor ?? .white
+        let highlightedTextColor = action.highlightedTextColor ?? tintColor
+        highlightedBackgroundColor = action.highlightedBackgroundColor ?? UIColor.black.withAlphaComponent(0.1)
+
+        innerButton.titleLabel?.font = action.font ?? UIFont.systemFont(ofSize: 15, weight: UIFont.Weight.medium)
+        innerButton.titleLabel?.textAlignment = .center
+        innerButton.titleLabel?.lineBreakMode = .byWordWrapping
+        innerButton.titleLabel?.numberOfLines = 0
+
+        accessibilityLabel = action.accessibilityLabel
+
+        innerButton.setTitle(action.title, for: .normal)
+        innerButton.setTitleColor(tintColor, for: .normal)
+        innerButton.setTitleColor(highlightedTextColor, for: .highlighted)
+        innerButton.setImage(action.image, for: .normal)
+        innerButton.setImage(action.highlightedImage ?? action.image, for: .highlighted)
+
+        addSubview(innerButton)
+        innerButton.translatesAutoresizingMaskIntoConstraints = false
+
+        NSLayoutConstraint.activate([
+            innerButton.leadingAnchor.constraint(equalTo: leadingAnchor),
+            innerButton.trailingAnchor.constraint(equalTo: trailingAnchor),
+            innerButton.topAnchor.constraint(equalTo: topAnchor),
+            innerButton.bottomAnchor.constraint(equalTo: bottomAnchor)
+        ])
+        innerButton.isUserInteractionEnabled = false
+    }
+
+    override var isHighlighted: Bool {
+        didSet {
+            innerButton.isHighlighted = isHighlighted
+            backgroundColor = isHighlighted ? highlightedBackgroundColor : normalBackgroundColor
+        }
+    }
+
+    override func preferredWidth(maximum: CGFloat) -> CGFloat {
+        let width = maximum > 0 ? maximum : CGFloat.greatestFiniteMagnitude
+        let textWidth = innerButton.titleBoundingRect(with: CGSize(width: width, height: CGFloat.greatestFiniteMagnitude)).width
+        let imageWidth = innerButton.currentImage?.size.width ?? 0
+        let contentWidth = max(textWidth, imageWidth) + innerButton.contentEdgeInsets.left + innerButton.contentEdgeInsets.right
+
+        return min(width, contentWidth)
+    }
+}
+
+private class InnerButtonContentView: UIButton {
+    var maximumImageHeight: CGFloat = 24
+    var spacing: CGFloat = 10
+    var verticalAlignment: SwipeVerticalAlignment = .centerFirstBaseline
+
+    override func titleRect(forContentRect contentRect: CGRect) -> CGRect {
+        var rect = contentRect.center(size: titleBoundingRect(with: contentRect.size).size)
+        rect.origin.y = alignmentRect.minY + imageHeight + currentSpacing
+        return rect.integral
+    }
+
+    override var intrinsicContentSize: CGSize {
+        CGSize(
+            width: UIView.noIntrinsicMetric,
+            height: contentEdgeInsets.top + alignmentRect.height + contentEdgeInsets.bottom
+        )
+    }
+
+    override func imageRect(forContentRect contentRect: CGRect) -> CGRect {
+        var rect = contentRect.center(size: currentImage?.size ?? .zero)
+        rect.origin.y = alignmentRect.minY + (imageHeight - rect.height) / 2
+        return rect
+    }
+
+    func titleBoundingRect(with size: CGSize) -> CGRect {
+        guard let title = currentTitle,
+              let font = titleLabel?.font else { return .zero }
+
+        return title.boundingRect(
+            with: size,
+            options: [.usesLineFragmentOrigin],
+            attributes: [NSAttributedString.Key.font: font],
+            context: nil
+        ).integral
+    }
+
+    var alignmentRect: CGRect {
+        let contentRect = contentRect(forBounds: bounds)
+        let titleHeight = titleBoundingRect(
+            with: verticalAlignment == .centerFirstBaseline ? CGRect.infinite.size : contentRect.size
+        ).integral.height
+        let totalHeight = imageHeight + titleHeight + currentSpacing
+
+        return contentRect.center(size: CGSize(width: contentRect.width, height: totalHeight))
+    }
+
+    private var imageHeight: CGFloat {
+        currentImage == nil ? 0 : maximumImageHeight
+    }
+
+    private var currentSpacing: CGFloat {
+        (currentTitle?.isEmpty == false && imageHeight > 0) ? spacing : 0
+    }
+}
+
+private extension CGRect {
+    func center(size: CGSize) -> CGRect {
+        let dx = width - size.width
+        let dy = height - size.height
+        return CGRect(x: origin.x + dx * 0.5, y: origin.y + dy * 0.5, width: size.width, height: size.height)
+    }
+}

--- a/Source/SwipeAction.swift
+++ b/Source/SwipeAction.swift
@@ -21,7 +21,7 @@ public enum SwipeActionStyle: Int {
  
  This class lets you define one or more custom actions to display for a given item in your table/collection. Each instance of this class represents a single action to perform and includes the text, formatting information, and behavior for the corresponding button.
  */
-public class SwipeAction: NSObject {
+open class SwipeAction: NSObject {
     /// An optional unique action identifier.
     public var identifier: String?
     

--- a/Source/SwipeActionButton.swift
+++ b/Source/SwipeActionButton.swift
@@ -25,6 +25,8 @@ class SwipeActionButton: UIControl {
         contentView = contentViewBuilder(action)
         contentView.isUserInteractionEnabled = false
         contentView.translatesAutoresizingMaskIntoConstraints = false
+        layer.cornerRadius = contentView.layer.cornerRadius
+        layer.cornerCurve = contentView.layer.cornerCurve
         addSubview(contentView)
         NSLayoutConstraint.activate([
             contentView.leadingAnchor.constraint(equalTo: leadingAnchor),

--- a/Source/SwipeActionButton.swift
+++ b/Source/SwipeActionButton.swift
@@ -7,102 +7,43 @@
 
 import UIKit
 
-class SwipeActionButton: UIButton {
-    var spacing: CGFloat = 8
+class SwipeActionButton: UIControl {
     var shouldHighlight = true
     var highlightedBackgroundColor: UIColor?
-
-    var maximumImageHeight: CGFloat = 0
     var verticalAlignment: SwipeVerticalAlignment = .centerFirstBaseline
-    
-    
-    var currentSpacing: CGFloat {
-        return (currentTitle?.isEmpty == false && imageHeight > 0) ? spacing : 0
-    }
-    
-    var alignmentRect: CGRect {
-        let contentRect = self.contentRect(forBounds: bounds)
-        let titleHeight = titleBoundingRect(with: verticalAlignment == .centerFirstBaseline ? CGRect.infinite.size : contentRect.size).integral.height
-        let totalHeight = imageHeight + titleHeight + currentSpacing
+    private var contentView: ActionContentView!
 
-        return contentRect.center(size: CGSize(width: contentRect.width, height: totalHeight))
-    }
-    
-    private var imageHeight: CGFloat {
-        get {
-            return currentImage == nil ? 0 : maximumImageHeight
-        }
-    }
-    
-    override var intrinsicContentSize: CGSize {
-        return CGSize(width: UIView.noIntrinsicMetric, height: contentEdgeInsets.top + alignmentRect.height + contentEdgeInsets.bottom)
-    }
-    
-    convenience init(action: SwipeAction) {
+    public convenience init(
+        action: SwipeAction,
+        contentViewBuilder: (SwipeAction) -> ActionContentView
+    ) {
         self.init(frame: .zero)
+        addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(tapControl)))
 
-        contentHorizontalAlignment = .center
-        
-        tintColor = action.textColor ?? .white
-        let highlightedTextColor = action.highlightedTextColor ?? tintColor
-        highlightedBackgroundColor = action.highlightedBackgroundColor ?? UIColor.black.withAlphaComponent(0.1)
-
-        titleLabel?.font = action.font ?? UIFont.systemFont(ofSize: 15, weight: UIFont.Weight.medium)
-        titleLabel?.textAlignment = .center
-        titleLabel?.lineBreakMode = .byWordWrapping
-        titleLabel?.numberOfLines = 0
-        
-        accessibilityLabel = action.accessibilityLabel
-        
-        setTitle(action.title, for: .normal)
-        setTitleColor(tintColor, for: .normal)
-        setTitleColor(highlightedTextColor, for: .highlighted)
-        setImage(action.image, for: .normal)
-        setImage(action.highlightedImage ?? action.image, for: .highlighted)
+        contentView = contentViewBuilder(action)
+        contentView.isUserInteractionEnabled = false
+        contentView.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(contentView)
+        NSLayoutConstraint.activate([
+            contentView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            contentView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            contentView.topAnchor.constraint(equalTo: topAnchor),
+            contentView.bottomAnchor.constraint(equalTo: bottomAnchor)
+        ])
     }
-    
+
+    @objc
+    private func tapControl() {
+        sendActions(for: .touchUpInside)
+    }
+
     override var isHighlighted: Bool {
         didSet {
-            guard shouldHighlight else { return }
-            
-            backgroundColor = isHighlighted ? highlightedBackgroundColor : .clear
+            contentView.isHighlighted = isHighlighted
         }
     }
-    
-    func preferredWidth(maximum: CGFloat) -> CGFloat {
-        let width = maximum > 0 ? maximum : CGFloat.greatestFiniteMagnitude
-        let textWidth = titleBoundingRect(with: CGSize(width: width, height: CGFloat.greatestFiniteMagnitude)).width
-        let imageWidth = currentImage?.size.width ?? 0
-        
-        return min(width, max(textWidth, imageWidth) + contentEdgeInsets.left + contentEdgeInsets.right)
-    }
-    
-    func titleBoundingRect(with size: CGSize) -> CGRect {
-        guard let title = currentTitle, let font = titleLabel?.font else { return .zero }
-        
-        return title.boundingRect(with: size,
-                                  options: [.usesLineFragmentOrigin],
-                                  attributes: [NSAttributedString.Key.font: font],
-                                  context: nil).integral
-    }
-    
-    override func titleRect(forContentRect contentRect: CGRect) -> CGRect {
-        var rect = contentRect.center(size: titleBoundingRect(with: contentRect.size).size)
-        rect.origin.y = alignmentRect.minY + imageHeight + currentSpacing
-        return rect.integral
-    }
-    
-    override func imageRect(forContentRect contentRect: CGRect) -> CGRect {
-        var rect = contentRect.center(size: currentImage?.size ?? .zero)
-        rect.origin.y = alignmentRect.minY + (imageHeight - rect.height) / 2
-        return rect
-    }
-}
 
-extension CGRect {
-    func center(size: CGSize) -> CGRect {
-        let dx = width - size.width
-        let dy = height - size.height
-        return CGRect(x: origin.x + dx * 0.5, y: origin.y + dy * 0.5, width: size.width, height: size.height)
+    func preferredWidth(maximum: CGFloat) -> CGFloat {
+        contentView.preferredWidth(maximum: maximum)
     }
 }

--- a/Source/SwipeActionButton.swift
+++ b/Source/SwipeActionButton.swift
@@ -20,6 +20,8 @@ class SwipeActionButton: UIControl {
         self.init(frame: .zero)
         addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(tapControl)))
 
+        accessibilityTraits = UIAccessibilityTraits.button
+        accessibilityLabel = action.accessibilityLabel ?? action.title
         contentView = contentViewBuilder(action)
         contentView.isUserInteractionEnabled = false
         contentView.translatesAutoresizingMaskIntoConstraints = false

--- a/Source/SwipeActionButton.swift
+++ b/Source/SwipeActionButton.swift
@@ -50,4 +50,8 @@ class SwipeActionButton: UIControl {
     func preferredWidth(maximum: CGFloat) -> CGFloat {
         contentView.preferredWidth(maximum: maximum)
     }
+
+    func updateExpansion(_ context: SwipeActionExpansionContext) {
+        contentView.didChangeExpansion(context)
+    }
 }

--- a/Source/SwipeActionTransitioning.swift
+++ b/Source/SwipeActionTransitioning.swift
@@ -25,7 +25,7 @@ public struct SwipeActionTransitioningContext {
     public let actionIdentifier: String?
     
     /// The button that is changing.
-    public let button: UIButton
+    public let button: UIView
     
     /// The old visibility percentage between 0.0 and 1.0.
     public let newPercentVisible: CGFloat
@@ -35,7 +35,7 @@ public struct SwipeActionTransitioningContext {
     
     internal let wrapperView: UIView
     
-    internal init(actionIdentifier: String?, button: UIButton, newPercentVisible: CGFloat, oldPercentVisible: CGFloat, wrapperView: UIView) {
+    internal init(actionIdentifier: String?, button: UIView, newPercentVisible: CGFloat, oldPercentVisible: CGFloat, wrapperView: UIView) {
         self.actionIdentifier = actionIdentifier
         self.button = button
         self.newPercentVisible = newPercentVisible

--- a/Source/SwipeActionTransitioning.swift
+++ b/Source/SwipeActionTransitioning.swift
@@ -12,9 +12,21 @@ import UIKit
  */
 public protocol SwipeActionTransitioning {
     /**
+     Gives the delegate an opportunity to configure the action before it becomes visible.
+
+     The supplied context has both visibility percentages set to zero. This method is
+     invoked synchronously during the action button's first valid layout.
+     */
+    func prepareTransition(with context: SwipeActionTransitioningContext)
+
+    /**
      Tells the delegate that transition change has occured.
      */
     func didTransition(with context: SwipeActionTransitioningContext) -> Void
+}
+
+public extension SwipeActionTransitioning {
+    func prepareTransition(with context: SwipeActionTransitioningContext) {}
 }
 
 /**
@@ -27,19 +39,30 @@ public struct SwipeActionTransitioningContext {
     /// The button that is changing.
     public let button: UIView
     
-    /// The old visibility percentage between 0.0 and 1.0.
+    /// The new visibility percentage between 0.0 and 1.0.
     public let newPercentVisible: CGFloat
     
-    /// The new visibility percentage between 0.0 and 1.0.
+    /// The old visibility percentage between 0.0 and 1.0.
     public let oldPercentVisible: CGFloat
-    
+
+    /// Whether the visibility change is driven directly by an active gesture.
+    public let isInteractive: Bool
+
     internal let wrapperView: UIView
     
-    internal init(actionIdentifier: String?, button: UIView, newPercentVisible: CGFloat, oldPercentVisible: CGFloat, wrapperView: UIView) {
+    internal init(
+        actionIdentifier: String?,
+        button: UIView,
+        newPercentVisible: CGFloat,
+        oldPercentVisible: CGFloat,
+        isInteractive: Bool = false,
+        wrapperView: UIView
+    ) {
         self.actionIdentifier = actionIdentifier
         self.button = button
         self.newPercentVisible = newPercentVisible
         self.oldPercentVisible = oldPercentVisible
+        self.isInteractive = isInteractive
         self.wrapperView = wrapperView
     }
     

--- a/Source/SwipeActionsView.swift
+++ b/Source/SwipeActionsView.swift
@@ -158,7 +158,6 @@ class SwipeActionsView: UIView {
     private func addButtons(for actions: [SwipeAction], withMaximum size: CGSize, contentEdgeInsets: UIEdgeInsets) -> [SwipeActionButton] {
         let maximum = options.maximumButtonWidth ?? (size.width - 30) / CGFloat(actions.count)
         let minimum = options.minimumButtonWidth ?? min(maximum, 74)
-        minimumButtonWidth = buttons.reduce(minimum, { initial, next in max(initial, next.preferredWidth(maximum: maximum)) })
 
         let buttons: [SwipeActionButton] = actions.map({ action in
             let actionButton = SwipeActionButton(
@@ -172,6 +171,8 @@ class SwipeActionsView: UIView {
             ]
             return actionButton
         })
+
+        minimumButtonWidth = buttons.reduce(minimum, { initial, next in max(initial, next.preferredWidth(maximum: maximum)) })
 
         buttons.enumerated().forEach { (index, button) in
             let action = actions[index]

--- a/Source/SwipeActionsView.swift
+++ b/Source/SwipeActionsView.swift
@@ -33,8 +33,24 @@ class SwipeActionsView: UIView {
     let contentEdgeInsets: UIEdgeInsets
 
     var buttons: [SwipeActionButton] = []
+    var buttonWidths: [CGFloat] = []
 
-    var minimumButtonWidth: CGFloat = 0
+    private var hasPreparedTransitions = false
+    private var wasInteractive = false
+    private var visibilityUpdateSequence = 0
+
+    var expandableButtonWidth: CGFloat {
+        buttonWidths.last ?? 0
+    }
+
+    var regularActionsWidth: CGFloat {
+        buttonWidths.reduce(0, +)
+    }
+
+    var preferredWidth: CGFloat {
+        return regularActionsWidth + safeAreaMargin
+    }
+
     var maximumImageHeight: CGFloat {
         return actions.reduce(0, { initial, next in max(initial, next.image?.size.height ?? 0) })
     }
@@ -45,27 +61,45 @@ class SwipeActionsView: UIView {
         return orientation == .left ? scrollView.safeAreaInsets.left : scrollView.safeAreaInsets.right
     }
 
-    var visibleWidth: CGFloat = 0 {
-        didSet {
-            // If necessary, adjust for safe areas
-            visibleWidth = max(0, visibleWidth - safeAreaMargin)
+    private(set) var visibleWidth: CGFloat = 0
+    private(set) var revealedWidth: CGFloat = 0
 
-            let preLayoutVisibleWidths = transitionLayout.visibleWidthsForViews(with: layoutContext)
+    func updateVisibleWidth(_ width: CGFloat, isInteractive: Bool = false) {
+        visibilityUpdateSequence += 1
 
-            layoutContext = ActionsViewLayoutContext.newContext(for: self)
+        let preLayoutVisibleWidths = transitionLayout.visibleWidthsForViews(with: layoutContext)
+        let interactionDidChange = wasInteractive != isInteractive
 
-            transitionLayout.container(view: self, didChangeVisibleWidthWithContext: layoutContext)
+        wasInteractive = isInteractive
+        revealedWidth = max(0, width)
+        visibleWidth = max(0, revealedWidth - safeAreaMargin) // If necessary, adjust for safe areas.
+        layoutContext = transitionLayoutContext()
+        transitionLayout.container(view: self, didChangeVisibleWidthWithContext: layoutContext)
 
-            setNeedsLayout()
-            layoutIfNeeded()
+        setNeedsLayout()
+        layoutIfNeeded()
 
-            notifyVisibleWidthChanged(oldWidths: preLayoutVisibleWidths,
-                                      newWidths: transitionLayout.visibleWidthsForViews(with: layoutContext))
-        }
+        notifyVisibleWidthChanged(
+            oldWidths: preLayoutVisibleWidths,
+            newWidths: transitionLayout.visibleWidthsForViews(with: layoutContext),
+            isInteractive: isInteractive,
+            interactionDidChange: interactionDidChange,
+            updateSequence: visibilityUpdateSequence
+        )
     }
 
-    var preferredWidth: CGFloat {
-        return minimumButtonWidth * CGFloat(actions.count) + safeAreaMargin
+    private func transitionLayoutContext() -> ActionsViewLayoutContext {
+        guard options.expansionStyle?.expandedActionLayout == .fillAvailableSpace,
+              visibleWidth > regularActionsWidth else {
+            return ActionsViewLayoutContext.newContext(for: self)
+        }
+
+        return ActionsViewLayoutContext(
+            buttonWidths: buttonWidths,
+            orientation: orientation,
+            contentSize: CGSize(width: regularActionsWidth, height: contentSize.height),
+            visibleWidth: regularActionsWidth
+        )
     }
 
     var contentSize: CGSize {
@@ -113,7 +147,10 @@ class SwipeActionsView: UIView {
             transitionLayout = DragTransitionLayout()
         }
 
-        self.layoutContext = ActionsViewLayoutContext(numberOfActions: actions.count, orientation: orientation)
+        self.layoutContext = ActionsViewLayoutContext(
+            buttonWidths: Array(repeating: 0, count: actions.count),
+            orientation: orientation
+        )
 
         feedbackGenerator = SwipeFeedback(style: .light)
         feedbackGenerator.prepare()
@@ -172,7 +209,20 @@ class SwipeActionsView: UIView {
             return actionButton
         })
 
-        minimumButtonWidth = buttons.reduce(minimum, { initial, next in max(initial, next.preferredWidth(maximum: maximum)) })
+        switch options.buttonWidthMode {
+        case .equal:
+            let sharedWidth = buttons.reduce(minimum) { initial, next in
+                max(initial, next.preferredWidth(maximum: maximum))
+            }
+
+            buttonWidths = buttons.map { _ in sharedWidth }
+        case .individual:
+            buttonWidths = buttons.map { button in
+                let preferredWidth = max(0, button.preferredWidth(maximum: maximum))
+                let width = max(max(0, minimum), preferredWidth)
+                return maximum > 0 ? min(maximum, width) : width
+            }
+        }
 
         buttons.enumerated().forEach { (index, button) in
             let action = actions[index]
@@ -180,7 +230,7 @@ class SwipeActionsView: UIView {
                 frame: .zero,
                 action: action,
                 orientation: orientation,
-                contentWidth: minimumButtonWidth,
+                contentWidth: buttonWidths[index],
                 options: options
             )
             wrapperView.layer.cornerRadius = button.layer.cornerRadius
@@ -272,24 +322,49 @@ class SwipeActionsView: UIView {
         notifyExpansion(expanded: expanded)
     }
 
-    func notifyVisibleWidthChanged(oldWidths: [CGFloat], newWidths: [CGFloat]) {
-        DispatchQueue.main.async {
-            guard self.buttons.count == oldWidths.count else { return }
+    func notifyVisibleWidthChanged(
+        oldWidths: [CGFloat],
+        newWidths: [CGFloat],
+        isInteractive: Bool,
+        interactionDidChange: Bool,
+        updateSequence: Int
+    ) {
+        let notify = { [weak self] in
+            guard let self = self,
+                  self.visibilityUpdateSequence == updateSequence,
+                  self.buttons.count == oldWidths.count,
+                  oldWidths.count == newWidths.count else {
+                return
+            }
 
             oldWidths.enumerated().forEach { index, oldWidth in
                 let newWidth = newWidths[index]
-                if oldWidth != newWidth {
+                if oldWidth != newWidth || interactionDidChange {
+                    let buttonWidth = self.buttonWidths[index]
                     let context = SwipeActionTransitioningContext(
                         actionIdentifier: self.actions[index].identifier,
                         button: self.buttons[index],
-                        newPercentVisible: newWidth / self.minimumButtonWidth,
-                        oldPercentVisible: oldWidth / self.minimumButtonWidth,
-                        wrapperView: self.subviews[index])
+                        newPercentVisible: self.percentVisible(newWidth, buttonWidth: buttonWidth),
+                        oldPercentVisible: self.percentVisible(oldWidth, buttonWidth: buttonWidth),
+                        isInteractive: isInteractive,
+                        wrapperView: self.subviews[index]
+                    )
 
                     self.actions[index].transitionDelegate?.didTransition(with: context)
                 }
             }
         }
+
+        if isInteractive {
+            notify()
+        } else {
+            DispatchQueue.main.async(execute: notify)
+        }
+    }
+
+    private func percentVisible(_ visibleWidth: CGFloat, buttonWidth: CGFloat) -> CGFloat {
+        guard buttonWidth > 0 else { return 0 }
+        return min(max(visibleWidth / buttonWidth, 0), 1)
     }
 
     func notifyExpansion(expanded: Bool) {
@@ -315,16 +390,89 @@ class SwipeActionsView: UIView {
             transitionLayout.layout(view: subview.element, atIndex: subview.offset, with: layoutContext)
         }
 
-        if expanded {
-            subviews.last?.frame.origin.x = 0 + bounds.origin.x
+        prepareTransitionsIfNeeded()
+        layoutExpansion()
+    }
+
+    private func layoutExpansion() {
+        guard let expansionStyle = options.expansionStyle else { return }
+
+        switch expansionStyle.expandedActionLayout {
+        case .edgeAligned:
+            if expanded {
+                subviews.last?.frame.origin.x = bounds.origin.x
+            }
+        case .fillAvailableSpace:
+            layoutFillAvailableSpaceAction()
+        }
+
+    }
+
+    private func layoutFillAvailableSpaceAction() {
+        guard let expandedButton = buttons.last,
+              let wrapperView = expandedButton.superview as? SwipeActionButtonWrapperView else {
+            return
+        }
+
+        let regularButtonWidth = expandableButtonWidth
+        let precedingActionsWidth = buttonWidths.dropLast().reduce(0, +)
+        let maximumWidth = max(regularButtonWidth, bounds.width - precedingActionsWidth)
+        let expandedWidth = min(
+            max(regularButtonWidth, visibleWidth - precedingActionsWidth),
+            maximumWidth
+        )
+        let contentRect = wrapperView.contentRect(forWidth: expandedWidth)
+
+        // The action button may have a spring scale transform applied. A view's
+        // frame is undefined while its transform is non-identity, so resizing it
+        // through frame can corrupt its bounds and center during a fast swipe.
+        expandedButton.bounds = CGRect(origin: .zero, size: contentRect.size)
+        expandedButton.center = CGPoint(x: contentRect.midX, y: contentRect.midY)
+        expandedButton.layoutIfNeeded()
+        expandedButton.updateExpansion(
+            SwipeActionExpansionContext(
+                regularWidth: regularButtonWidth,
+                currentWidth: expandedWidth,
+                maximumWidth: maximumWidth
+            )
+        )
+        expandedButton.layoutIfNeeded()
+    }
+
+    private func prepareTransitionsIfNeeded() {
+        guard !hasPreparedTransitions,
+              bounds.width > 0,
+              bounds.height > 0,
+              buttons.count == actions.count,
+              subviews.count == actions.count else {
+            return
+        }
+
+        hasPreparedTransitions = true
+
+        actions.indices.forEach { index in
+            actions[index].transitionDelegate?.prepareTransition(
+                with: SwipeActionTransitioningContext(
+                    actionIdentifier: actions[index].identifier,
+                    button: buttons[index],
+                    newPercentVisible: 0,
+                    oldPercentVisible: 0,
+                    wrapperView: subviews[index]
+                )
+            )
         }
     }
 }
 
 class SwipeActionButtonWrapperView: UIView {
-    let contentRect: CGRect
+    private let orientation: SwipeActionsOrientation
+    private let contentWidth: CGFloat
     var actionBackgroundColor: UIColor?
     private let cleanBackgroundToClear: Bool
+
+    var contentRect: CGRect {
+        contentRect(forWidth: contentWidth)
+    }
 
     init(
         frame: CGRect,
@@ -333,13 +481,8 @@ class SwipeActionButtonWrapperView: UIView {
         contentWidth: CGFloat,
         options: SwipeOptions
     ) {
-        switch orientation {
-        case .left:
-            contentRect = CGRect(x: frame.width - contentWidth, y: 0, width: contentWidth, height: frame.height)
-        case .right:
-            contentRect = CGRect(x: 0, y: 0, width: contentWidth, height: frame.height)
-        }
-
+        self.orientation = orientation
+        self.contentWidth = contentWidth
         cleanBackgroundToClear = options.backgroundColor == .clear
         super.init(frame: frame)
 
@@ -349,6 +492,18 @@ class SwipeActionButtonWrapperView: UIView {
         } else {
             backgroundColor = actionBackgroundColor
         }
+    }
+
+    func contentRect(forWidth width: CGFloat) -> CGRect {
+        let width = max(width, 0)
+        let originX: CGFloat = switch orientation {
+        case .left:
+            bounds.width - width
+        case .right:
+            0
+        }
+
+        return CGRect(x: originX, y: 0, width: width, height: bounds.height)
     }
 
     func cleanBackground() {

--- a/Source/SwipeCollectionViewCell.swift
+++ b/Source/SwipeCollectionViewCell.swift
@@ -7,7 +7,6 @@
 //
 
 import UIKit
-
 /**
  The `SwipeCollectionViewCell` class extends `UICollectionViewCell` and provides more flexible options for cell swiping behavior.
  
@@ -92,7 +91,7 @@ open class SwipeCollectionViewCell: UICollectionViewCell {
                 contentView.bottomAnchor.constraint(equalTo: self.bottomAnchor),
             ])
         }
-        
+
         swipeController = SwipeController(swipeable: self, actionsContainerView: contentView)
         swipeController.delegate = self
     }

--- a/Source/SwipeCollectionViewCell.swift
+++ b/Source/SwipeCollectionViewCell.swift
@@ -208,6 +208,14 @@ open class SwipeCollectionViewCell: UICollectionViewCell {
 }
 
 extension SwipeCollectionViewCell: SwipeControllerDelegate {
+    func actionContentView(_ controller: SwipeController, for action: SwipeAction) -> ActionContentView {
+        guard let delegate = delegate,
+            let collectionView = collectionView else {
+                fatalError("Delegate should be not nil when request content view for action")
+        }
+        return delegate.collectionView(collectionView, contentViewForAction: action)
+    }
+
     func swipeController(_ controller: SwipeController, canBeginEditingSwipeableFor orientation: SwipeActionsOrientation) -> Bool {
         return true
     }

--- a/Source/SwipeCollectionViewCell.swift
+++ b/Source/SwipeCollectionViewCell.swift
@@ -193,6 +193,7 @@ open class SwipeCollectionViewCell: UICollectionViewCell {
     func reset() {
         contentView.clipsToBounds = false
         swipeController.reset()
+        swipeController.resetSwipe()
         collectionView?.setGestureEnabled(true)
     }
     

--- a/Source/SwipeCollectionViewCell.swift
+++ b/Source/SwipeCollectionViewCell.swift
@@ -96,6 +96,20 @@ open class SwipeCollectionViewCell: UICollectionViewCell {
         swipeController.delegate = self
     }
     
+    // Preserve contentView's horizontal offset during layout passes (e.g. reconfigureItems).
+    // contentView is pinned to cell edges via Auto Layout, so super.layoutSubviews() resets
+    // contentView.center.x — collapsing an open swipe even though state is still active.
+    /// :nodoc:
+    override open func layoutSubviews() {
+        if state.isActive {
+            let contentCenterX = contentView.center.x
+            super.layoutSubviews()
+            contentView.center.x = contentCenterX
+        } else {
+            super.layoutSubviews()
+        }
+    }
+
     /// :nodoc:
     override open func prepareForReuse() {
         super.prepareForReuse()

--- a/Source/SwipeCollectionViewCellDelegate.swift
+++ b/Source/SwipeCollectionViewCellDelegate.swift
@@ -10,7 +10,7 @@ import UIKit
 /**
  The `SwipeCollectionViewCellDelegate` protocol is adopted by an object that manages the display of action buttons when the item is swiped.
  */
-public protocol SwipeCollectionViewCellDelegate: class {
+public protocol SwipeCollectionViewCellDelegate: AnyObject {
     /**
      Asks the delegate for the actions to display in response to a swipe in the specified item.
      
@@ -23,7 +23,19 @@ public protocol SwipeCollectionViewCellDelegate: class {
      - returns: An array of `SwipeAction` objects representing the actions for the item. Each action you provide is used to create a button that the user can tap.  Returning `nil` will prevent swiping for the supplied orientation.
      */
     func collectionView(_ collectionView: UICollectionView, editActionsForItemAt indexPath: IndexPath, for orientation: SwipeActionsOrientation) -> [SwipeAction]?
-    
+
+    /**
+     Asks the delegate to build specific view for given SwipeAction.
+     - parameter collectionView: The collection view object which owns the item requesting this information.
+     - parameter action: SwipeAction which required a view reperesentation.
+
+     - returns: Intialised view conformed ActionContentView protocol.
+     */
+    func collectionView(
+        _ collectionView: UICollectionView,
+        contentViewForAction action: SwipeAction
+    ) -> ActionContentView
+
     /**
      Asks the delegate for the display options to be used while presenting the action buttons.
      
@@ -87,5 +99,12 @@ public extension SwipeCollectionViewCellDelegate {
     
     func visibleRect(for collectionView: UICollectionView) -> CGRect? {
         return nil
+    }
+
+    func collectionView(
+        _ collectionView: UICollectionView,
+        contentViewForAction action: SwipeAction
+    ) -> ActionContentView {
+        DefaultActionContentView(action: action)
     }
 }

--- a/Source/SwipeController.swift
+++ b/Source/SwipeController.swift
@@ -410,8 +410,7 @@ extension SwipeController: UIGestureRecognizerDelegate {
     private func getPanZone(_ zone: PanZoneWidth, width: CGFloat) -> CGFloat {
         switch zone {
         case let .fractional(multiplier):
-            let fraction = abs(multiplier - multiplier.rounded(.down))
-            return width * fraction
+            return width * multiplier
         case let .absolute(absoluteValue):
             return absoluteValue
         }

--- a/Source/SwipeController.swift
+++ b/Source/SwipeController.swift
@@ -391,12 +391,20 @@ extension SwipeController: UIGestureRecognizerDelegate {
             var leftPanZone: CGFloat = 0
             let width = swipeable.bounds.width
             if let leftOptions = delegate?.swipeController(self, editActionsOptionsForSwipeableFor: .left) {
-                leftPanZone = getPanZone(leftOptions.leftPanZone, width: width)
+                leftPanZone = getPanZone(
+                    leftOptions.leftPanZone,
+                    width: width,
+                    state: swipeable.state
+                )
             }
 
             var rightPanZone: CGFloat = 0
             if let rightOptions = delegate?.swipeController(self, editActionsOptionsForSwipeableFor: .right) {
-                rightPanZone = width - getPanZone(rightOptions.rightPanZone, width: width)
+                rightPanZone = width - getPanZone(
+                    rightOptions.rightPanZone,
+                    width: width,
+                    state: swipeable.state
+                )
             }
 
             let isInPanZone = translation.x < 0 ? location.x >= rightPanZone : location.x <= leftPanZone
@@ -407,7 +415,12 @@ extension SwipeController: UIGestureRecognizerDelegate {
         return true
     }
 
-    private func getPanZone(_ zone: PanZoneWidth, width: CGFloat) -> CGFloat {
+    private func getPanZone(_ zone: PanZoneWidth, width: CGFloat, state: SwipeState) -> CGFloat {
+        // When actions are shown do not check swipe zone.
+        guard ![SwipeState.right, SwipeState.left].contains(state)  else {
+            return width
+        }
+
         switch zone {
         case let .fractional(multiplier):
             return width * multiplier

--- a/Source/SwipeController.swift
+++ b/Source/SwipeController.swift
@@ -66,7 +66,7 @@ class SwipeController: NSObject {
 
     @objc func handlePan(gesture: UIPanGestureRecognizer) {
         guard let target = actionsContainerView, var swipeable = self.swipeable else { return }
-        
+
         let velocity = gesture.velocity(in: target)
         
         if delegate?.swipeController(self, canBeginEditingSwipeableFor: velocity.x > 0 ? .left : .right) == false {
@@ -211,10 +211,11 @@ class SwipeController: NSObject {
         
         swipeable.actionsView?.removeFromSuperview()
         swipeable.actionsView = nil
-        
+
         var contentEdgeInsets = UIEdgeInsets.zero
-        if let visibleTableViewRect = delegate?.swipeController(self, visibleRectFor: scrollView) {
-            
+        if let userEdgeInsets = options.edgeInsets {
+            contentEdgeInsets = userEdgeInsets
+        } else if let visibleTableViewRect = delegate?.swipeController(self, visibleRectFor: scrollView) {
             let frame = (swipeable as Swipeable).frame
             let visibleSwipeableRect = frame.intersection(visibleTableViewRect)
             if visibleSwipeableRect.isNull == false {
@@ -241,9 +242,10 @@ class SwipeController: NSObject {
         actionsView.delegate = self
         
         actionsContainerView.addSubview(actionsView)
+        actionsView.addButtons()
         
         actionsView.heightAnchor.constraint(equalTo: swipeable.heightAnchor).isActive = true
-        actionsView.widthAnchor.constraint(equalTo: swipeable.widthAnchor, multiplier: 2).isActive = true
+        actionsView.widthAnchor.constraint(equalTo: swipeable.widthAnchor).isActive = true
         actionsView.topAnchor.constraint(equalTo: swipeable.topAnchor).isActive = true
         
         if orientation == .left {
@@ -382,7 +384,24 @@ extension SwipeController: UIGestureRecognizerDelegate {
             let view = gestureRecognizer.view,
             let gestureRecognizer = gestureRecognizer as? UIPanGestureRecognizer {
             let translation = gestureRecognizer.translation(in: view)
-            return abs(translation.y) <= abs(translation.x)
+
+            let location = gestureRecognizer.location(in: view)
+            guard let swipeable = swipeable else { return false }
+
+            var leftPanArea: CGFloat = 0
+            let width = swipeable.bounds.width
+            if let leftOptions = delegate?.swipeController(self, editActionsOptionsForSwipeableFor: .left) {
+                leftPanArea = width * leftOptions.leftSwipeAreaMultiplier
+            }
+
+            var rightPanArea: CGFloat = 0
+            if let rightOptions = delegate?.swipeController(self, editActionsOptionsForSwipeableFor: .right) {
+                rightPanArea = width - width * rightOptions.rightSwipeAreaMultiplier
+            }
+
+            let isInPanArea = translation.x < 0 ? location.x > rightPanArea : location.x < leftPanArea
+
+            return abs(translation.y) <= abs(translation.x) && isInPanArea
         }
         
         return true

--- a/Source/SwipeController.swift
+++ b/Source/SwipeController.swift
@@ -360,6 +360,8 @@ class SwipeController: NSObject {
         
         swipeable?.actionsView?.removeFromSuperview()
         swipeable?.actionsView = nil
+
+        actionsContainerView?.mask = nil
     }
     
 }
@@ -582,9 +584,11 @@ extension SwipeController: SwipeActionsViewDelegate {
         
         if animated {
             animate(toOffset: targetCenter) { complete in
+                swipeable.state = targetState
                 completion?(complete)
             }
         } else {
+            swipeable.state = targetState
             actionsContainerView.center.x = targetCenter
             swipeable.actionsView?.visibleWidth = abs(actionsContainerView.frame.minX)
         }

--- a/Source/SwipeController.swift
+++ b/Source/SwipeController.swift
@@ -388,26 +388,26 @@ extension SwipeController: UIGestureRecognizerDelegate {
             let location = gestureRecognizer.location(in: view)
             guard let swipeable = swipeable else { return false }
 
-            var leftPanArea: CGFloat = 0
+            var leftPanZone: CGFloat = 0
             let width = swipeable.bounds.width
             if let leftOptions = delegate?.swipeController(self, editActionsOptionsForSwipeableFor: .left) {
-                leftPanArea = getPanArea(leftOptions.leftPanZone, width: width)
+                leftPanZone = getPanZone(leftOptions.leftPanZone, width: width)
             }
 
-            var rightPanArea: CGFloat = 0
+            var rightPanZone: CGFloat = 0
             if let rightOptions = delegate?.swipeController(self, editActionsOptionsForSwipeableFor: .right) {
-                rightPanArea = width - getPanArea(rightOptions.rightPanZone, width: width)
+                rightPanZone = width - getPanZone(rightOptions.rightPanZone, width: width)
             }
 
-            let isInPanArea = translation.x < 0 ? location.x >= rightPanArea : location.x <= leftPanArea
+            let isInPanZone = translation.x < 0 ? location.x >= rightPanZone : location.x <= leftPanZone
 
-            return abs(translation.y) <= abs(translation.x) && isInPanArea
+            return abs(translation.y) <= abs(translation.x) && isInPanZone
         }
         
         return true
     }
 
-    private func getPanArea(_ zone: PanZoneWidth, width: CGFloat) -> CGFloat {
+    private func getPanZone(_ zone: PanZoneWidth, width: CGFloat) -> CGFloat {
         switch zone {
         case let .fractional(multiplier):
             let fraction = abs(multiplier - multiplier.rounded(.down))

--- a/Source/SwipeController.swift
+++ b/Source/SwipeController.swift
@@ -391,20 +391,30 @@ extension SwipeController: UIGestureRecognizerDelegate {
             var leftPanArea: CGFloat = 0
             let width = swipeable.bounds.width
             if let leftOptions = delegate?.swipeController(self, editActionsOptionsForSwipeableFor: .left) {
-                leftPanArea = width * leftOptions.leftSwipeAreaMultiplier
+                leftPanArea = getPanArea(leftOptions.leftPanZone, width: width)
             }
 
             var rightPanArea: CGFloat = 0
             if let rightOptions = delegate?.swipeController(self, editActionsOptionsForSwipeableFor: .right) {
-                rightPanArea = width - width * rightOptions.rightSwipeAreaMultiplier
+                rightPanArea = width - getPanArea(rightOptions.rightPanZone, width: width)
             }
 
-            let isInPanArea = translation.x < 0 ? location.x > rightPanArea : location.x < leftPanArea
+            let isInPanArea = translation.x < 0 ? location.x >= rightPanArea : location.x <= leftPanArea
 
             return abs(translation.y) <= abs(translation.x) && isInPanArea
         }
         
         return true
+    }
+
+    private func getPanArea(_ zone: PanZoneWidth, width: CGFloat) -> CGFloat {
+        switch zone {
+        case let .fractional(multiplier):
+            let fraction = abs(multiplier - multiplier.rounded(.down))
+            return width * fraction
+        case let .absolute(absoluteValue):
+            return absoluteValue
+        }
     }
 }
 

--- a/Source/SwipeController.swift
+++ b/Source/SwipeController.swift
@@ -417,7 +417,7 @@ extension SwipeController: UIGestureRecognizerDelegate {
 
     private func getPanZone(_ zone: PanZoneWidth, width: CGFloat, state: SwipeState) -> CGFloat {
         // When actions are shown do not check swipe zone.
-        guard ![SwipeState.right, SwipeState.left].contains(state)  else {
+        guard ![SwipeState.right, SwipeState.left].contains(state) else {
             return width
         }
 

--- a/Source/SwipeController.swift
+++ b/Source/SwipeController.swift
@@ -108,7 +108,10 @@ class SwipeController: NSObject {
                 target.center.x = gesture.elasticTranslation(in: target,
                                                              withLimit: .zero,
                                                              fromOriginalCenter: CGPoint(x: originalCenter, y: 0)).x
-                swipeable.actionsView?.visibleWidth = abs((swipeable as Swipeable).frame.minX)
+                swipeable.actionsView?.updateVisibleWidth(
+                    abs((swipeable as Swipeable).frame.minX),
+                    isInteractive: true
+                )
                 scrollRatio = elasticScrollRatio
                 return
             }
@@ -134,7 +137,10 @@ class SwipeController: NSObject {
                                                                  withLimit: CGSize(width: targetOffset, height: 0),
                                                                  fromOriginalCenter: CGPoint(x: originalCenter, y: 0),
                                                                  applyingRatio: expansionStyle.targetOverscrollElasticity).x
-                    swipeable.actionsView?.visibleWidth = abs(actionsContainerView.frame.minX)
+                    swipeable.actionsView?.updateVisibleWidth(
+                        abs(actionsContainerView.frame.minX),
+                        isInteractive: true
+                    )
 
                     if currentOffset/targetOffset > 1.0,
                         let wrapper = actionsView.buttons.last?.superview as? SwipeActionButtonWrapperView {
@@ -148,7 +154,10 @@ class SwipeController: NSObject {
                                                              withLimit: CGSize(width: actionsView.preferredWidth, height: 0),
                                                              fromOriginalCenter: CGPoint(x: originalCenter, y: 0),
                                                              applyingRatio: elasticScrollRatio).x
-                swipeable.actionsView?.visibleWidth = abs(actionsContainerView.frame.minX)
+                swipeable.actionsView?.updateVisibleWidth(
+                    abs(actionsContainerView.frame.minX),
+                    isInteractive: true
+                )
                 
                 if (target.center.x - originalCenter) / translation != 1.0 {
                     scrollRatio = elasticScrollRatio
@@ -288,7 +297,7 @@ class SwipeController: NSObject {
             guard let swipeable = self.swipeable, let actionsContainerView = self.actionsContainerView else { return }
             
             actionsContainerView.center = CGPoint(x: offset, y: actionsContainerView.center.y)
-            swipeable.actionsView?.visibleWidth = abs(actionsContainerView.frame.minX)
+            swipeable.actionsView?.updateVisibleWidth(abs(actionsContainerView.frame.minX))
             swipeable.layoutIfNeeded()
         })
         
@@ -311,7 +320,7 @@ class SwipeController: NSObject {
         if swipeable.state == .left || swipeable.state == .right {
             let targetOffset = targetCenter(active: swipeable.state.isActive)
             actionsContainerView.center = CGPoint(x: targetOffset, y: actionsContainerView.center.y)
-            swipeable.actionsView?.visibleWidth = abs(actionsContainerView.frame.minX)
+            swipeable.actionsView?.updateVisibleWidth(abs(actionsContainerView.frame.minX))
             swipeable.layoutIfNeeded()
         }        
     }
@@ -333,14 +342,33 @@ class SwipeController: NSObject {
     }
     
     func targetState(forVelocity velocity: CGPoint) -> SwipeState {
-        guard let actionsView = swipeable?.actionsView else { return .center }
-        
-        switch actionsView.orientation {
-        case .left:
-            return (velocity.x < 0 && !actionsView.expanded) ? .center : .left
-        case .right:
-            return (velocity.x > 0 && !actionsView.expanded) ? .center : .right
+        guard let swipeable = swipeable, let actionsView = swipeable.actionsView else { return .center }
+
+        if actionsView.expanded {
+            return SwipeState(orientation: actionsView.orientation)
         }
+
+        if swipeable.state == .dragging, let activationThreshold = actionsView.options.activationThreshold {
+            let thresholdValue = getActivationThreshold(
+                activationThreshold,
+                width: actionsView.bounds.width
+            )
+
+            return actionsView.revealedWidth >= thresholdValue
+                ? SwipeState(orientation: actionsView.orientation)
+                : .center
+        }
+
+        let isClosing: Bool = switch actionsView.orientation {
+        case .left:
+            velocity.x < 0
+        case .right:
+            velocity.x > 0
+        }
+
+        return isClosing
+            ? .center
+            : SwipeState(orientation: actionsView.orientation)
     }
     
     func targetCenter(active: Bool) -> CGFloat {
@@ -417,6 +445,15 @@ extension SwipeController: UIGestureRecognizerDelegate {
         return true
     }
 
+    private func getActivationThreshold(_ threshold: SwipeActionsActivationThreshold, width: CGFloat) -> CGFloat {
+        switch threshold {
+        case let .fractional(multiplier):
+            return width * multiplier
+        case let .absolute(absoluteValue):
+            return absoluteValue
+        }
+    }
+
     private func getPanZone(_ zone: PanZoneWidth, width: CGFloat, state: SwipeState) -> CGFloat {
         // When actions are shown do not check swipe zone.
         guard ![SwipeState.right, SwipeState.left].contains(state) else {
@@ -469,7 +506,7 @@ extension SwipeController: SwipeActionsViewDelegate {
         guard let swipeable = self.swipeable, let actionsContainerView = self.actionsContainerView else { return }
         guard let actionsView = swipeable.actionsView, let indexPath = swipeable.indexPath else { return }
 
-        let newCenter = swipeable.bounds.midX - (swipeable.bounds.width + actionsView.minimumButtonWidth) * actionsView.orientation.scale
+        let newCenter = swipeable.bounds.midX - (swipeable.bounds.width + actionsView.expandableButtonWidth) * actionsView.orientation.scale
         
         action.completionHandler = { [weak self] style in
             guard let `self` = self else { return }
@@ -488,7 +525,7 @@ extension SwipeController: SwipeActionsViewDelegate {
                     
                     actionsContainerView.center.x = newCenter
                     actionsContainerView.mask?.frame.size.height = 0
-                    swipeable.actionsView?.visibleWidth = abs(actionsContainerView.frame.minX)
+                    swipeable.actionsView?.updateVisibleWidth(abs(actionsContainerView.frame.minX))
                     
                     if fillOption.timing == .after {
                         actionsView.alpha = 0
@@ -538,7 +575,7 @@ extension SwipeController: SwipeActionsViewDelegate {
             }
         } else {
             actionsContainerView.center = CGPoint(x: targetCenter, y: actionsContainerView.center.y)
-            swipeable.actionsView?.visibleWidth = abs(actionsContainerView.frame.minX)
+            swipeable.actionsView?.updateVisibleWidth(abs(actionsContainerView.frame.minX))
             reset()
         }
         
@@ -551,7 +588,7 @@ extension SwipeController: SwipeActionsViewDelegate {
         let targetCenter = self.targetCenter(active: false)
         
         actionsContainerView.center = CGPoint(x: targetCenter, y: actionsContainerView.center.y)
-        swipeable.actionsView?.visibleWidth = abs(actionsContainerView.frame.minX)
+        swipeable.actionsView?.updateVisibleWidth(abs(actionsContainerView.frame.minX))
     }
     
     func showSwipe(orientation: SwipeActionsOrientation, animated: Bool = true, completion: ((Bool) -> Void)? = nil) {
@@ -590,7 +627,7 @@ extension SwipeController: SwipeActionsViewDelegate {
         } else {
             swipeable.state = targetState
             actionsContainerView.center.x = targetCenter
-            swipeable.actionsView?.visibleWidth = abs(actionsContainerView.frame.minX)
+            swipeable.actionsView?.updateVisibleWidth(abs(actionsContainerView.frame.minX))
         }
     }
 }

--- a/Source/SwipeExpanding.swift
+++ b/Source/SwipeExpanding.swift
@@ -22,7 +22,7 @@ public protocol SwipeExpanding {
      - parameter otherActionButtons: The other action buttons in the view, not including the action button being expanded.
      */
 
-    func animationTimingParameters(buttons: [UIButton], expanding: Bool) -> SwipeExpansionAnimationTimingParameters
+    func animationTimingParameters(buttons: [UIView], expanding: Bool) -> SwipeExpansionAnimationTimingParameters
     
     /**
      Tells your object when the expansion state is changing.
@@ -33,7 +33,7 @@ public protocol SwipeExpanding {
 
      - parameter otherActionButtons: The other action buttons in the view, not including the action button being expanded.
      */
-    func actionButton(_ button: UIButton, didChange expanding: Bool, otherActionButtons: [UIButton])
+    func actionButton(_ button: UIView, didChange expanding: Bool, otherActionButtons: [UIView])
 }
 
 /**
@@ -100,14 +100,14 @@ public struct ScaleAndAlphaExpansion: SwipeExpanding {
     }
 
     /// :nodoc:    
-    public func animationTimingParameters(buttons: [UIButton], expanding: Bool) -> SwipeExpansionAnimationTimingParameters {
+    public func animationTimingParameters(buttons: [UIView], expanding: Bool) -> SwipeExpansionAnimationTimingParameters {
         var timingParameters = SwipeExpansionAnimationTimingParameters.default
         timingParameters.delay = expanding ? interButtonDelay : 0
         return timingParameters
     }
     
     /// :nodoc:
-    public func actionButton(_ button: UIButton, didChange expanding: Bool, otherActionButtons: [UIButton]) {
+    public func actionButton(_ button: UIView, didChange expanding: Bool, otherActionButtons: [UIView]) {
         let buttons = expanding ? otherActionButtons : otherActionButtons.reversed()
         
         buttons.enumerated().forEach { index, button in

--- a/Source/SwipeExpansionStyle.swift
+++ b/Source/SwipeExpansionStyle.swift
@@ -53,6 +53,9 @@ public struct SwipeExpansionStyle {
     
     /// Specifies the expansion animation completion style.
     public let completionAnimation: CompletionAnimation
+
+    /// Controls how the primary action is laid out while expansion is revealed.
+    public var expandedActionLayout: ExpandedActionLayout
     
     /// Specifies the minimum amount of overscroll required if the configured target is less than the fully exposed action view.
     public var minimumTargetOverscroll: CGFloat = 20
@@ -65,23 +68,27 @@ public struct SwipeExpansionStyle {
     var minimumExpansionTranslation: CGFloat = 8.0
     
     /**
-     Contructs a new `SwipeExpansionStyle` instance.
-     
-     - parameter target: The relative target expansion threshold. Expansion will occur at the specified value.
-     
-     - parameter additionalTriggers: Additional triggers to useful for determining if expansion should occur.
-     
-     - parameter elasticOverscroll: Specifies if buttons should expand to fully fill overscroll, or expand at a percentage relative to the overscroll.
+     Constructs a new `SwipeExpansionStyle` instance.
 
-     - parameter completionAnimation: Specifies the expansion animation completion style.
-
-     - returns: The new `SwipeExpansionStyle` instance.
+     - parameter target: The relative target expansion threshold.
+     - parameter additionalTriggers: Additional expansion triggers.
+     - parameter elasticOverscroll: Whether buttons fill all overscroll.
+     - parameter completionAnimation: The expansion completion style.
+     - parameter expandedActionLayout: How the primary action is laid out after
+       the regular actions are fully exposed.
      */
-    public init(target: Target, additionalTriggers: [Trigger] = [], elasticOverscroll: Bool = false, completionAnimation: CompletionAnimation = .bounce) {
+    public init(
+        target: Target,
+        additionalTriggers: [Trigger] = [],
+        elasticOverscroll: Bool = false,
+        completionAnimation: CompletionAnimation = .bounce,
+        expandedActionLayout: ExpandedActionLayout = .edgeAligned
+    ) {
         self.target = target
         self.additionalTriggers = additionalTriggers
         self.elasticOverscroll = elasticOverscroll
         self.completionAnimation = completionAnimation
+        self.expandedActionLayout = expandedActionLayout
     }
     
     func shouldExpand(view: Swipeable, gesture: UIPanGestureRecognizer, in superview: UIView, within frame: CGRect? = nil) -> Bool {
@@ -111,7 +118,18 @@ public struct SwipeExpansionStyle {
     }
 }
 
-extension SwipeExpansionStyle {    
+extension SwipeExpansionStyle {
+    /// Describes how the primary action is positioned and sized during expansion.
+    public enum ExpandedActionLayout: Equatable {
+        /// Preserves the original behavior, aligning the primary action to the
+        /// exposed edge once expansion is armed.
+        case edgeAligned
+
+        /// Keeps preceding actions attached to the cell and grows the primary
+        /// action across the remaining exposed width.
+        case fillAvailableSpace
+    }
+
     /// Describes the relative target expansion threshold. Expansion will occur at the specified value.
     public enum Target {
         /// The target is specified by a percentage.

--- a/Source/SwipeOptions.swift
+++ b/Source/SwipeOptions.swift
@@ -44,7 +44,16 @@ public struct SwipeOptions {
     
     /// The amount of space, in points, between the button image and the button title.
     public var buttonSpacing: CGFloat?
-    
+
+    /// Custom edge insets of swipe view if not set will be either .zero or calculated from delegate provided visible rect
+    public var edgeInsets: UIEdgeInsets?
+
+    /// Sets up left swipe zone as fractional of a cell width. 1 - all cell will respond to pan gesture. 0.3 - only left 30% of a cell width will respond.
+    public var leftSwipeAreaMultiplier: CGFloat = 1
+
+    /// Sets up right swipe zone as fractional of a cell width. 1 - all cell will respond to pan gesture. 0.3 - only right 30% of a cell width will respond.
+    public var rightSwipeAreaMultiplier: CGFloat = 1
+
     /// Constructs a new `SwipeOptions` instance with default options.
     public init() {}
 }

--- a/Source/SwipeOptions.swift
+++ b/Source/SwipeOptions.swift
@@ -48,14 +48,19 @@ public struct SwipeOptions {
     /// Custom edge insets of swipe view if not set will be either .zero or calculated from delegate provided visible rect
     public var edgeInsets: UIEdgeInsets?
 
-    /// Sets up left swipe zone as fractional of a cell width. 1 - all cell will respond to pan gesture. 0.3 - only left 30% of a cell width will respond.
-    public var leftSwipeAreaMultiplier: CGFloat = 1
+    /// Sets up left swipe zone. There are two options fractional of cell width and absolute value used by pan gesture.
+    public var leftPanZone: PanZoneWidth = .fractional(1)
 
-    /// Sets up right swipe zone as fractional of a cell width. 1 - all cell will respond to pan gesture. 0.3 - only right 30% of a cell width will respond.
-    public var rightSwipeAreaMultiplier: CGFloat = 1
+    /// Sets up right swipe zone. There are two options fractional of cell width and absolute value used by pan gesture.
+    public var rightPanZone: PanZoneWidth = .fractional(1)
 
     /// Constructs a new `SwipeOptions` instance with default options.
     public init() {}
+}
+
+public enum PanZoneWidth {
+    case fractional(_ multiplier: CGFloat)
+    case absolute(_ width: CGFloat)
 }
 
 /// Describes the transition style. Transition is the style of how the action buttons are exposed during the swipe.

--- a/Source/SwipeOptions.swift
+++ b/Source/SwipeOptions.swift
@@ -35,6 +35,14 @@ public struct SwipeOptions {
     ///
     /// - note: By default, the system chooses an appropriate size.
     public var minimumButtonWidth: CGFloat?
+
+    /// Determines whether actions share one width or use their content's
+    /// individual preferred widths.
+    ///
+    /// The default `.equal` mode preserves the original shared-width behavior.
+    /// The `.individual` mode clamps each preferred width to
+    /// `minimumButtonWidth...maximumButtonWidth`.
+    public var buttonWidthMode: SwipeButtonWidthMode = .equal
     
     /// The vertical alignment mode used for when a button image and title are present.
     public var buttonVerticalAlignment: SwipeVerticalAlignment = .centerFirstBaseline
@@ -54,8 +62,33 @@ public struct SwipeOptions {
     /// Sets up right swipe zone. There are two options fractional of cell width and absolute value used by pan gesture.
     public var rightPanZone: PanZoneWidth = .fractional(1)
 
+    /// The distance from the closed position the cell must be swiped before its actions remain visible after release.
+    /// When unset, the release velocity direction determines whether the actions open.
+    public var activationThreshold: SwipeActionsActivationThreshold?
+
     /// Constructs a new `SwipeOptions` instance with default options.
     public init() {}
+}
+
+/// Defines how far a cell must be dragged before its actions remain open when
+/// the gesture ends.
+public enum SwipeActionsActivationThreshold {
+    /// Requires the cell to expose the supplied fraction of its width.
+    ///
+    /// Values from `0...1` represent zero to the full cell width.
+    case fractional(CGFloat)
+
+    /// Requires the cell to expose the supplied number of points.
+    case absolute(CGFloat)
+}
+
+/// Describes how regular action button widths are resolved.
+public enum SwipeButtonWidthMode {
+    /// Every action uses the width required by the widest action.
+    case equal
+
+    /// Every action uses its own content's preferred width.
+    case individual
 }
 
 public enum PanZoneWidth {

--- a/Source/SwipeTableViewCell.swift
+++ b/Source/SwipeTableViewCell.swift
@@ -189,6 +189,13 @@ extension SwipeTableViewCell: SwipeControllerDelegate {
         
         return delegate?.tableView(tableView, editActionsForRowAt: indexPath, for: orientation)
     }
+
+    func actionContentView(_ controller: SwipeController, for action: SwipeAction) -> ActionContentView {
+        guard let tableView = tableView, let delegate = delegate else {
+            fatalError("Delegate should be not nil when request content view for action")
+        }
+        return delegate.tableView(tableView, contentViewForAction: action)
+    }
     
     func swipeController(_ controller: SwipeController, editActionsOptionsForSwipeableFor orientation: SwipeActionsOrientation) -> SwipeOptions {
         guard let tableView = tableView, let indexPath = tableView.indexPath(for: self) else { return SwipeOptions() }

--- a/Source/SwipeTableViewCellDelegate.swift
+++ b/Source/SwipeTableViewCellDelegate.swift
@@ -10,7 +10,7 @@ import UIKit
 /**
  The `SwipeTableViewCellDelegate` protocol is adopted by an object that manages the display of action buttons when the cell is swiped.
  */
-public protocol SwipeTableViewCellDelegate: class {
+public protocol SwipeTableViewCellDelegate: AnyObject {
     
     /**
      Asks the delegate for the actions to display in response to a swipe in the specified row.
@@ -24,7 +24,19 @@ public protocol SwipeTableViewCellDelegate: class {
      - returns: An array of `SwipeAction` objects representing the actions for the row. Each action you provide is used to create a button that the user can tap.  Returning `nil` will prevent swiping for the supplied orientation.
      */
     func tableView(_ tableView: UITableView, editActionsForRowAt indexPath: IndexPath, for orientation: SwipeActionsOrientation) -> [SwipeAction]?
-    
+
+    /**
+     Asks the delegate for the content view for action button.
+     - parameter tableView: The table view object wich owns the cell requsted this information.
+     - parameter action: SwipeAction model
+
+     - returns: An action content view
+     */
+    func tableView(
+        _ tableView: UITableView,
+        contentViewForAction action: SwipeAction
+    ) -> ActionContentView
+
     /**
      Asks the delegate for the display options to be used while presenting the action buttons.
      
@@ -88,5 +100,12 @@ public extension SwipeTableViewCellDelegate {
     
     func visibleRect(for tableView: UITableView) -> CGRect? {
         return nil
+    }
+
+    func tableView(
+        _ tableView: UITableView,
+        contentViewForAction action: SwipeAction
+    ) -> ActionContentView {
+        DefaultActionContentView(action: action)
     }
 }

--- a/Source/SwipeTransitionLayout.swift
+++ b/Source/SwipeTransitionLayout.swift
@@ -18,26 +18,35 @@ protocol SwipeTransitionLayout {
 // MARK: - Layout Context 
 
 struct ActionsViewLayoutContext {
-    let numberOfActions: Int
     let orientation: SwipeActionsOrientation
     let contentSize: CGSize
     let visibleWidth: CGFloat
-    let minimumButtonWidth: CGFloat
-    
-    init(numberOfActions: Int, orientation: SwipeActionsOrientation, contentSize: CGSize = .zero, visibleWidth: CGFloat = 0, minimumButtonWidth: CGFloat = 0) {
-        self.numberOfActions = numberOfActions
+    let buttonWidths: [CGFloat]
+
+    init(
+        buttonWidths: [CGFloat],
+        orientation: SwipeActionsOrientation,
+        contentSize: CGSize = .zero,
+        visibleWidth: CGFloat = 0
+    ) {
+        self.buttonWidths = buttonWidths
         self.orientation = orientation
         self.contentSize = contentSize
         self.visibleWidth = visibleWidth
-        self.minimumButtonWidth = minimumButtonWidth
     }
-    
+
+    func offset(before index: Int) -> CGFloat {
+        guard index > 0 else { return 0 }
+        return buttonWidths.prefix(index).reduce(0, +)
+    }
+
     static func newContext(for actionsView: SwipeActionsView) -> ActionsViewLayoutContext {
-        return ActionsViewLayoutContext(numberOfActions: actionsView.actions.count,
-                                        orientation: actionsView.orientation,
-                                        contentSize: actionsView.contentSize,
-                                        visibleWidth: actionsView.visibleWidth,
-                                        minimumButtonWidth: actionsView.minimumButtonWidth)
+        return ActionsViewLayoutContext(
+            buttonWidths: actionsView.buttonWidths,
+            orientation: actionsView.orientation,
+            contentSize: actionsView.contentSize,
+            visibleWidth: actionsView.visibleWidth
+        )
     }
 }
 
@@ -48,16 +57,26 @@ class BorderTransitionLayout: SwipeTransitionLayout {
     }
     
     func layout(view: UIView, atIndex index: Int, with context: ActionsViewLayoutContext) {
+        guard context.totalButtonWidth > 0 else {
+            return
+        }
+
         let diff = context.visibleWidth - context.contentSize.width
-        view.frame.origin.x = (CGFloat(index) * context.contentSize.width / CGFloat(context.numberOfActions) + diff) * context.orientation.scale
+        let revealScale = context.contentSize.width / context.totalButtonWidth
+        view.frame.origin.x = (context.offset(before: index) * revealScale + diff) * context.orientation.scale
     }
     
     func visibleWidthsForViews(with context: ActionsViewLayoutContext) -> [CGFloat] {
-        let diff = context.visibleWidth - context.contentSize.width
-        let visibleWidth = context.contentSize.width / CGFloat(context.numberOfActions) + diff
+        guard context.totalButtonWidth > 0 else {
+            return context.buttonWidths.map { _ in 0 }
+        }
 
-        // visible widths are all the same regardless of the action view position
-        return (0..<context.numberOfActions).map({ _ in visibleWidth })
+        let diff = context.visibleWidth - context.contentSize.width
+        let revealScale = context.contentSize.width / context.totalButtonWidth
+
+        return context.buttonWidths.map {
+            max(0, $0 * revealScale + diff)
+        }
     }
 }
 
@@ -67,22 +86,41 @@ class DragTransitionLayout: SwipeTransitionLayout {
     }
     
     func layout(view: UIView, atIndex index: Int, with context: ActionsViewLayoutContext) {
-        view.frame.origin.x = (CGFloat(index) * context.minimumButtonWidth) * context.orientation.scale
+        view.frame.origin.x = context.offset(before: index) * context.orientation.scale
     }
     
     func visibleWidthsForViews(with context: ActionsViewLayoutContext) -> [CGFloat] {
-        return (0..<context.numberOfActions)
-            .map({ max(0, min(context.minimumButtonWidth, context.visibleWidth - (CGFloat($0) * context.minimumButtonWidth))) })
+        var remainingWidth = context.visibleWidth
+
+        return context.buttonWidths.map { buttonWidth in
+            let visibleWidth = max(0, min(buttonWidth, remainingWidth))
+            remainingWidth -= buttonWidth
+            return visibleWidth
+        }
     }
 }
 
 class RevealTransitionLayout: DragTransitionLayout {
     override func container(view: UIView, didChangeVisibleWidthWithContext context: ActionsViewLayoutContext) {
-        let width = context.minimumButtonWidth * CGFloat(context.numberOfActions)
-        view.bounds.origin.x = (width - context.visibleWidth) * context.orientation.scale
+        view.bounds.origin.x = (context.totalButtonWidth - context.visibleWidth) * context.orientation.scale
     }
     
     override func visibleWidthsForViews(with context: ActionsViewLayoutContext) -> [CGFloat] {
-        return super.visibleWidthsForViews(with: context).reversed()
+        var remainingWidth = context.visibleWidth
+        var visibleWidths = context.buttonWidths.map { _ in CGFloat(0) }
+
+        for index in context.buttonWidths.indices.reversed() {
+            let buttonWidth = context.buttonWidths[index]
+            visibleWidths[index] = max(0, min(buttonWidth, remainingWidth))
+            remainingWidth -= buttonWidth
+        }
+
+        return visibleWidths
+    }
+}
+
+private extension ActionsViewLayoutContext {
+    var totalButtonWidth: CGFloat {
+        buttonWidths.reduce(0, +)
     }
 }

--- a/SwipeCellKit.podspec
+++ b/SwipeCellKit.podspec
@@ -14,5 +14,5 @@ Pod::Spec.new do |s|
 
    s.swift_version = '5.0'
 
-   s.ios.deployment_target = '9.0'
+   s.ios.deployment_target = '13.0'
 end

--- a/SwipeCellKit.xcodeproj/project.pbxproj
+++ b/SwipeCellKit.xcodeproj/project.pbxproj
@@ -9,6 +9,8 @@
 /* Begin PBXBuildFile section */
 		11D4999D20B0D65400A1F4E7 /* SwipeController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11D4999C20B0D65400A1F4E7 /* SwipeController.swift */; };
 		170BCE721E8340C000F46E18 /* SwipeAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 170BCE711E8340C000F46E18 /* SwipeAnimator.swift */; };
+		290FF0B22823E8B300212EAE /* DefaultActionContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 290FF0B12823E8B300212EAE /* DefaultActionContentView.swift */; };
+		29FC1D192823C73A00F48AA8 /* ActionContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29FC1D182823C73A00F48AA8 /* ActionContentView.swift */; };
 		3F19AD041E8D711C006B4B3A /* SwipeFeedback.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F19AD031E8D711C006B4B3A /* SwipeFeedback.swift */; };
 		3F234AC81E44A7A400E22A38 /* SwipeCellKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 3F234AC61E44A7A400E22A38 /* SwipeCellKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3F234AD61E44A94F00E22A38 /* SwipeTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F234AD21E44A94F00E22A38 /* SwipeTableViewCell.swift */; };
@@ -35,11 +37,13 @@
 /* Begin PBXFileReference section */
 		11D4999C20B0D65400A1F4E7 /* SwipeController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwipeController.swift; sourceTree = "<group>"; };
 		170BCE711E8340C000F46E18 /* SwipeAnimator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwipeAnimator.swift; sourceTree = "<group>"; };
+		290FF0B12823E8B300212EAE /* DefaultActionContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultActionContentView.swift; sourceTree = "<group>"; };
+		29FC1D182823C73A00F48AA8 /* ActionContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionContentView.swift; sourceTree = "<group>"; };
 		3F19AD031E8D711C006B4B3A /* SwipeFeedback.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwipeFeedback.swift; sourceTree = "<group>"; };
 		3F234AC31E44A7A400E22A38 /* SwipeCellKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwipeCellKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3F234AC61E44A7A400E22A38 /* SwipeCellKit.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SwipeCellKit.h; sourceTree = "<group>"; };
 		3F234AC71E44A7A400E22A38 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		3F234AD21E44A94F00E22A38 /* SwipeTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = SwipeTableViewCell.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
+		3F234AD21E44A94F00E22A38 /* SwipeTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = SwipeTableViewCell.swift; sourceTree = "<group>"; };
 		3F234AD31E44A94F00E22A38 /* SwipeAction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwipeAction.swift; sourceTree = "<group>"; };
 		3F234AD41E44A94F00E22A38 /* SwipeActionsView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwipeActionsView.swift; sourceTree = "<group>"; };
 		3F234AD51E44A94F00E22A38 /* Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Extensions.swift; sourceTree = "<group>"; };
@@ -107,6 +111,8 @@
 				3F234AD41E44A94F00E22A38 /* SwipeActionsView.swift */,
 				3F234AD31E44A94F00E22A38 /* SwipeAction.swift */,
 				3F3ED70F1E486993009DD5D8 /* SwipeActionButton.swift */,
+				29FC1D182823C73A00F48AA8 /* ActionContentView.swift */,
+				290FF0B12823E8B300212EAE /* DefaultActionContentView.swift */,
 				3FD016E01E6D7F7700B54FFC /* SwipeActionTransitioning.swift */,
 				3F4C721C1E7E8BC20097399A /* SwipeExpansionStyle.swift */,
 				3FD016DE1E6D778700B54FFC /* SwipeExpanding.swift */,
@@ -211,10 +217,12 @@
 				3F3ED7101E486993009DD5D8 /* SwipeActionButton.swift in Sources */,
 				B93ECA931EDEE88800AE05AD /* SwipeCollectionViewCell+Display.swift in Sources */,
 				3F234AD61E44A94F00E22A38 /* SwipeTableViewCell.swift in Sources */,
+				29FC1D192823C73A00F48AA8 /* ActionContentView.swift in Sources */,
 				3F19AD041E8D711C006B4B3A /* SwipeFeedback.swift in Sources */,
 				B93ECA951EDEE8A700AE05AD /* SwipeCollectionViewCellDelegate.swift in Sources */,
 				3FD016701E696D8D00B54FFC /* SwipeTransitionLayout.swift in Sources */,
 				3FA78CA11E5A5A0B00A1D8FF /* SwipeTableViewCell+Accessibility.swift in Sources */,
+				290FF0B22823E8B300212EAE /* DefaultActionContentView.swift in Sources */,
 				B93ECA8F1EDEE80700AE05AD /* SwipeCollectionViewCell.swift in Sources */,
 				3F4C721F1E7E8C180097399A /* Swipeable.swift in Sources */,
 				3F4C721D1E7E8BC20097399A /* SwipeExpansionStyle.swift in Sources */,
@@ -284,7 +292,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -340,7 +348,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
@@ -363,7 +371,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = "$(SRCROOT)/Source/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MARKETING_VERSION = 2.7.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jerkoch.SwipeCellKit;
@@ -386,7 +394,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = "$(SRCROOT)/Source/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MARKETING_VERSION = 2.7.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jerkoch.SwipeCellKit;

--- a/SwipeCellKit.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/SwipeCellKit.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Tests/SwipeActionsViewTests.swift
+++ b/Tests/SwipeActionsViewTests.swift
@@ -1,0 +1,168 @@
+//
+//  SwipeActionsViewTests.swift
+//  SwipeCellKitTests
+//
+
+import XCTest
+@testable import SwipeCellKit
+
+final class SwipeActionsViewTests: XCTestCase {
+    func testEqualWidthModeUsesWidestPreferredWidthForEveryAction() {
+        var options = SwipeOptions()
+        options.minimumButtonWidth = 20
+        options.maximumButtonWidth = 100
+
+        let fixture = makeActionsView(widths: [40, 80, 60], options: options)
+
+        XCTAssertEqual(fixture.view.buttonWidths, [80, 80, 80])
+    }
+
+    func testIndividualWidthModeUsesEachPreferredWidth() {
+        var options = SwipeOptions()
+        options.minimumButtonWidth = 20
+        options.maximumButtonWidth = 100
+        options.buttonWidthMode = .individual
+
+        let fixture = makeActionsView(widths: [40, 80, 60], options: options)
+
+        XCTAssertEqual(fixture.view.buttonWidths, [60, 80, 40])
+        XCTAssertEqual(fixture.view.preferredWidth, 180)
+    }
+
+    func testIndividualWidthModeClampsEachWidthToConfiguredLimits() {
+        var options = SwipeOptions()
+        options.minimumButtonWidth = 30
+        options.maximumButtonWidth = 100
+        options.buttonWidthMode = .individual
+
+        let fixture = makeActionsView(widths: [10, 120], options: options)
+
+        XCTAssertEqual(fixture.view.buttonWidths, [100, 30])
+    }
+
+    func testTransitionPreparationOccursOnce() {
+        let transition = TransitionSpy()
+        let fixture = makeActionsView(widths: [40, 80, 60], transitionDelegate: transition)
+
+        fixture.view.updateVisibleWidth(100, isInteractive: true)
+        fixture.view.updateVisibleWidth(120, isInteractive: true)
+
+        XCTAssertEqual(transition.preparationContexts.count, 3)
+        XCTAssertTrue(transition.preparationContexts.allSatisfy {
+            $0.newPercentVisible == 0 && $0.oldPercentVisible == 0
+        })
+    }
+
+    func testTransitionContextReportsInteractionAndClampsVisibility() {
+        let transition = TransitionSpy()
+        let fixture = makeActionsView(widths: [50], transitionDelegate: transition)
+        transition.transitionContexts.removeAll()
+
+        fixture.view.updateVisibleWidth(500, isInteractive: true)
+
+        XCTAssertEqual(transition.transitionContexts.count, 1)
+        XCTAssertEqual(transition.transitionContexts.first?.newPercentVisible, 1)
+        XCTAssertEqual(transition.transitionContexts.first?.oldPercentVisible, 0)
+        XCTAssertEqual(transition.transitionContexts.first?.isInteractive, true)
+    }
+
+    func testTransitionContextReportsSettlingTarget() {
+        let transition = TransitionSpy()
+        var options = SwipeOptions()
+        options.minimumButtonWidth = 50
+        options.maximumButtonWidth = 50
+        let fixture = makeActionsView(
+            widths: [50],
+            options: options,
+            transitionDelegate: transition
+        )
+        fixture.view.updateVisibleWidth(25, isInteractive: true)
+        transition.transitionContexts.removeAll()
+
+        fixture.view.updateVisibleWidth(50)
+
+        let transitionReported = expectation(description: "Transition reported")
+        DispatchQueue.main.async {
+            XCTAssertEqual(transition.transitionContexts.count, 1)
+            XCTAssertEqual(transition.transitionContexts.first?.newPercentVisible, 1)
+            XCTAssertEqual(transition.transitionContexts.first?.isInteractive, false)
+            transitionReported.fulfill()
+        }
+        waitForExpectations(timeout: 1)
+    }
+
+    func testFillAvailableSpaceFreezesBorderLayoutAndExpandsPrimaryAction() {
+        var options = SwipeOptions()
+        options.minimumButtonWidth = 20
+        options.maximumButtonWidth = 100
+        options.buttonWidthMode = .individual
+        options.transitionStyle = .border
+        options.expansionStyle = SwipeExpansionStyle(
+            target: .percentage(0.8),
+            expandedActionLayout: .fillAvailableSpace
+        )
+        let fixture = makeActionsView(widths: [40, 80, 60], options: options)
+
+        fixture.view.updateVisibleWidth(230, isInteractive: true)
+
+        XCTAssertEqual(fixture.view.layoutContext.visibleWidth, 180)
+        XCTAssertEqual(fixture.view.layoutContext.contentSize.width, 180)
+        XCTAssertEqual(fixture.view.subviews.map { $0.frame.origin.x }, [0, 60, 140])
+        XCTAssertEqual(fixture.view.buttons.last?.bounds.width, 90)
+        XCTAssertEqual(fixture.contentViews["0"]?.expansionContexts.last?.regularWidth, 40)
+        XCTAssertEqual(fixture.contentViews["0"]?.expansionContexts.last?.currentWidth, 90)
+        XCTAssertEqual(fixture.contentViews["0"]?.expansionContexts.last?.maximumWidth, 180)
+        XCTAssertEqual(fixture.contentViews["0"]?.expansionContexts.last?.additionalWidth, 50)
+    }
+
+    func testFillAvailableSpaceSupportsLeftOrientation() {
+        var options = SwipeOptions()
+        options.minimumButtonWidth = 20
+        options.maximumButtonWidth = 100
+        options.buttonWidthMode = .individual
+        options.transitionStyle = .border
+        options.expansionStyle = SwipeExpansionStyle(
+            target: .percentage(0.8),
+            expandedActionLayout: .fillAvailableSpace
+        )
+        let fixture = makeActionsView(
+            widths: [40, 80, 60],
+            options: options,
+            orientation: .left
+        )
+
+        fixture.view.updateVisibleWidth(230, isInteractive: true)
+
+        XCTAssertEqual(fixture.view.subviews.map { $0.frame.origin.x }, [0, -60, -140])
+        XCTAssertEqual(fixture.view.buttons.last?.bounds.width, 90)
+    }
+
+    func testClearExpandableActionUsesAutomaticScaleAndAlphaExpansion() {
+        var options = SwipeOptions()
+        options.expansionStyle = .destructive
+        let fixture = makeActionsView(
+            widths: [50, 50, 50],
+            options: options,
+            clearExpandableAction: true
+        )
+
+        XCTAssertTrue(fixture.view.expansionDelegate is ScaleAndAlphaExpansion)
+    }
+
+    func testCustomExpansionDelegateControlsOtherActionsAppearance() {
+        let expansionDelegate = ExpansionSpy()
+        var options = SwipeOptions()
+        options.expansionStyle = .destructive
+        options.expansionDelegate = expansionDelegate
+        let fixture = makeActionsView(widths: [50, 50, 50], options: options)
+
+        UIView.setAnimationsEnabled(false)
+        fixture.view.setExpanded(expanded: true)
+        fixture.view.layoutIfNeeded()
+        UIView.setAnimationsEnabled(true)
+
+        XCTAssertEqual(expansionDelegate.changes, [true])
+        XCTAssertEqual(fixture.view.buttons.dropLast().map { $0.alpha }, [0.5, 0.5])
+        XCTAssertEqual(fixture.view.buttons.dropLast().map { $0.transform.a }, [0.8, 0.8])
+    }
+}

--- a/Tests/SwipeControllerTests.swift
+++ b/Tests/SwipeControllerTests.swift
@@ -1,0 +1,143 @@
+//
+//  SwipeControllerTests.swift
+//  SwipeCellKitTests
+//
+
+import XCTest
+@testable import SwipeCellKit
+
+final class SwipeControllerTests: XCTestCase {
+    func testAbsoluteActivationThresholdUsesDistanceForClosingVelocity() {
+        var options = SwipeOptions()
+        options.activationThreshold = .absolute(50)
+        let fixture = makeActionsView(widths: [50], options: options)
+        fixture.view.updateVisibleWidth(60, isInteractive: true)
+        let swipeable = SwipeableMock(frame: fixture.view.bounds)
+        swipeable.actionsView = fixture.view
+        swipeable.state = .dragging
+        let controller = SwipeController(
+            swipeable: swipeable,
+            actionsContainerView: swipeable
+        )
+
+        let state = controller.targetState(forVelocity: CGPoint(x: 100, y: 0))
+
+        XCTAssertEqual(state, .right)
+    }
+
+    func testAbsoluteActivationThresholdHidesBelowDistanceForOpeningVelocity() {
+        var options = SwipeOptions()
+        options.activationThreshold = .absolute(50)
+        let fixture = makeActionsView(widths: [50], options: options)
+        fixture.view.updateVisibleWidth(49, isInteractive: true)
+        let swipeable = SwipeableMock(frame: fixture.view.bounds)
+        swipeable.actionsView = fixture.view
+        swipeable.state = .dragging
+        let controller = SwipeController(
+            swipeable: swipeable,
+            actionsContainerView: swipeable
+        )
+
+        let state = controller.targetState(forVelocity: CGPoint(x: -100, y: 0))
+
+        XCTAssertEqual(state, .center)
+    }
+
+    func testFractionalActivationThresholdUsesCellWidth() {
+        var options = SwipeOptions()
+        options.activationThreshold = .fractional(0.25)
+        let fixture = makeActionsView(widths: [50], options: options)
+        let swipeable = SwipeableMock(frame: fixture.view.bounds)
+        swipeable.actionsView = fixture.view
+        swipeable.state = .dragging
+        let controller = SwipeController(
+            swipeable: swipeable,
+            actionsContainerView: swipeable
+        )
+
+        fixture.view.updateVisibleWidth(79, isInteractive: true)
+        XCTAssertEqual(
+            controller.targetState(forVelocity: CGPoint(x: -100, y: 0)),
+            .center
+        )
+
+        fixture.view.updateVisibleWidth(80, isInteractive: true)
+        XCTAssertEqual(
+            controller.targetState(forVelocity: CGPoint(x: 100, y: 0)),
+            .right
+        )
+    }
+
+    func testDefaultActivationBehaviorStillUsesVelocityDirection() {
+        let fixture = makeActionsView(widths: [50])
+        fixture.view.updateVisibleWidth(1, isInteractive: true)
+        let swipeable = SwipeableMock(frame: fixture.view.bounds)
+        swipeable.actionsView = fixture.view
+        swipeable.state = .dragging
+        let controller = SwipeController(
+            swipeable: swipeable,
+            actionsContainerView: swipeable
+        )
+
+        XCTAssertEqual(
+            controller.targetState(forVelocity: CGPoint(x: -100, y: 0)),
+            .right
+        )
+        XCTAssertEqual(
+            controller.targetState(forVelocity: CGPoint(x: 100, y: 0)),
+            .center
+        )
+    }
+
+    func testActivationThresholdSupportsLeftOrientation() {
+        var options = SwipeOptions()
+        options.activationThreshold = .absolute(50)
+        let fixture = makeActionsView(
+            widths: [50],
+            options: options,
+            orientation: .left
+        )
+        let swipeable = SwipeableMock(frame: fixture.view.bounds)
+        swipeable.actionsView = fixture.view
+        swipeable.state = .dragging
+        let controller = SwipeController(
+            swipeable: swipeable,
+            actionsContainerView: swipeable
+        )
+
+        fixture.view.updateVisibleWidth(60, isInteractive: true)
+        XCTAssertEqual(
+            controller.targetState(forVelocity: CGPoint(x: -100, y: 0)),
+            .left
+        )
+
+        fixture.view.updateVisibleWidth(49, isInteractive: true)
+        XCTAssertEqual(
+            controller.targetState(forVelocity: CGPoint(x: 100, y: 0)),
+            .center
+        )
+    }
+
+    func testActivationThresholdDoesNotChangeDefaultDeactivationBehavior() {
+        var options = SwipeOptions()
+        options.activationThreshold = .absolute(50)
+        let fixture = makeActionsView(widths: [50], options: options)
+        fixture.view.updateVisibleWidth(60, isInteractive: true)
+        let swipeable = SwipeableMock(frame: fixture.view.bounds)
+        swipeable.actionsView = fixture.view
+        swipeable.state = .right
+        let controller = SwipeController(
+            swipeable: swipeable,
+            actionsContainerView: swipeable
+        )
+
+        XCTAssertEqual(
+            controller.targetState(forVelocity: CGPoint(x: 100, y: 0)),
+            .center
+        )
+        XCTAssertEqual(
+            controller.targetState(forVelocity: CGPoint(x: -100, y: 0)),
+            .right
+        )
+    }
+}

--- a/Tests/SwipeOptionsTests.swift
+++ b/Tests/SwipeOptionsTests.swift
@@ -1,0 +1,28 @@
+//
+//  SwipeOptionsTests.swift
+//  SwipeCellKitTests
+//
+
+import XCTest
+@testable import SwipeCellKit
+
+final class SwipeOptionsTests: XCTestCase {
+    func testNewOptionsPreserveOriginalDefaults() {
+        let options = SwipeOptions()
+
+        switch options.buttonWidthMode {
+        case .equal:
+            break
+        case .individual:
+            XCTFail("Expected equal button widths by default")
+        }
+
+        XCTAssertNil(options.activationThreshold)
+    }
+
+    func testExpansionStyleDefaultsToEdgeAlignedLayout() {
+        let style = SwipeExpansionStyle(target: .percentage(0.5))
+
+        XCTAssertEqual(style.expandedActionLayout, .edgeAligned)
+    }
+}

--- a/Tests/SwipeTransitionLayoutTests.swift
+++ b/Tests/SwipeTransitionLayoutTests.swift
@@ -1,0 +1,67 @@
+//
+//  SwipeTransitionLayoutTests.swift
+//  SwipeCellKitTests
+//
+
+import XCTest
+@testable import SwipeCellKit
+
+final class SwipeTransitionLayoutTests: XCTestCase {
+    func testDragTransitionUsesIndividualButtonWidths() {
+        let context = ActionsViewLayoutContext(
+            buttonWidths: [40, 80, 60],
+            orientation: .right,
+            contentSize: CGSize(width: 100, height: 80),
+            visibleWidth: 100
+        )
+
+        let visibleWidths = DragTransitionLayout().visibleWidthsForViews(with: context)
+
+        XCTAssertEqual(visibleWidths, [40, 60, 0])
+    }
+
+    func testRevealTransitionUsesIndividualButtonWidthsFromCellEdge() {
+        let context = ActionsViewLayoutContext(
+            buttonWidths: [40, 80, 60],
+            orientation: .right,
+            contentSize: CGSize(width: 100, height: 80),
+            visibleWidth: 100
+        )
+
+        let visibleWidths = RevealTransitionLayout().visibleWidthsForViews(with: context)
+
+        XCTAssertEqual(visibleWidths, [0, 40, 60])
+    }
+
+    func testBorderTransitionDistributesWidthProportionally() {
+        let context = ActionsViewLayoutContext(
+            buttonWidths: [40, 80, 60],
+            orientation: .right,
+            contentSize: CGSize(width: 90, height: 80),
+            visibleWidth: 90
+        )
+
+        let visibleWidths = BorderTransitionLayout().visibleWidthsForViews(with: context)
+
+        XCTAssertEqual(visibleWidths[0], 20)
+        XCTAssertEqual(visibleWidths[1], 40)
+        XCTAssertEqual(visibleWidths[2], 30)
+    }
+
+    func testLayoutsUseCumulativeOriginsForIndividualWidths() {
+        let views = (0..<3).map { _ in UIView() }
+        let context = ActionsViewLayoutContext(
+            buttonWidths: [40, 80, 60],
+            orientation: .right,
+            contentSize: CGSize(width: 180, height: 80),
+            visibleWidth: 180
+        )
+
+        views.enumerated().forEach {
+            DragTransitionLayout().layout(view: $0.element, atIndex: $0.offset, with: context)
+        }
+
+        let origins = views.map { $0.frame.origin.x }
+        XCTAssertEqual(origins, [0, 40, 120])
+    }
+}

--- a/Tests/TestSupport.swift
+++ b/Tests/TestSupport.swift
@@ -1,0 +1,148 @@
+//
+//  TestSupport.swift
+//  SwipeCellKitTests
+//
+
+import UIKit
+@testable import SwipeCellKit
+
+final class TestActionContentView: ActionContentView {
+    let width: CGFloat
+    var expansionContexts: [SwipeActionExpansionContext] = []
+
+    init(action: SwipeAction, width: CGFloat) {
+        self.width = width
+        super.init(action: action)
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func preferredWidth(maximum: CGFloat) -> CGFloat {
+        width
+    }
+
+    override func didChangeExpansion(_ context: SwipeActionExpansionContext) {
+        expansionContexts.append(context)
+    }
+}
+
+final class TransitionSpy: SwipeActionTransitioning {
+    var preparationContexts: [SwipeActionTransitioningContext] = []
+    var transitionContexts: [SwipeActionTransitioningContext] = []
+
+    func prepareTransition(with context: SwipeActionTransitioningContext) {
+        preparationContexts.append(context)
+    }
+
+    func didTransition(with context: SwipeActionTransitioningContext) {
+        transitionContexts.append(context)
+    }
+}
+
+final class ExpansionSpy: SwipeExpanding {
+    var changes: [Bool] = []
+
+    func animationTimingParameters(
+        buttons: [UIView],
+        expanding: Bool
+    ) -> SwipeExpansionAnimationTimingParameters {
+        SwipeExpansionAnimationTimingParameters(duration: 0)
+    }
+
+    func actionButton(
+        _ button: UIView,
+        didChange expanding: Bool,
+        otherActionButtons: [UIView]
+    ) {
+        changes.append(expanding)
+        otherActionButtons.forEach {
+            $0.alpha = expanding ? 0.5 : 1
+            $0.transform = expanding
+                ? CGAffineTransform(scaleX: 0.8, y: 0.8)
+                : .identity
+        }
+    }
+}
+
+final class SwipeableMock: UIView, Swipeable {
+    var state: SwipeState = .center
+    var actionsView: SwipeActionsView?
+    var scrollView: UIScrollView?
+    var indexPath: IndexPath?
+    let testPanGestureRecognizer = UIPanGestureRecognizer()
+
+    var panGestureRecognizer: UIGestureRecognizer {
+        testPanGestureRecognizer
+    }
+}
+
+struct ActionsViewFixture {
+    let containerView: UIView
+    let view: SwipeActionsView
+    let actions: [SwipeAction]
+    let contentViews: [String: TestActionContentView]
+}
+
+func makeActionsView(
+    widths: [CGFloat],
+    options: SwipeOptions = SwipeOptions(),
+    orientation: SwipeActionsOrientation = .right,
+    transitionDelegate: SwipeActionTransitioning? = nil,
+    clearExpandableAction: Bool = false,
+    size: CGSize = CGSize(width: 320, height: 80)
+) -> ActionsViewFixture {
+    let actions = widths.enumerated().map { index, _ -> SwipeAction in
+        let action = SwipeAction(style: .default, title: nil, handler: nil)
+        action.identifier = String(index)
+        action.transitionDelegate = transitionDelegate
+        return action
+    }
+
+    if clearExpandableAction {
+        actions.first?.backgroundColor = .clear
+    }
+
+    let widthsByIdentifier = Dictionary(
+        uniqueKeysWithValues: zip(actions, widths).map { action, width in
+            (action.identifier!, width)
+        }
+    )
+    var contentViews: [String: TestActionContentView] = [:]
+    let containerView = UIView()
+
+    let view = SwipeActionsView(
+        contentEdgeInsets: .zero,
+        maxSize: size,
+        safeAreaInsetView: containerView,
+        options: options,
+        orientation: orientation,
+        actions: actions,
+        actionContentViewBuilder: { action in
+            let identifier = action.identifier!
+            let contentView = TestActionContentView(
+                action: action,
+                width: widthsByIdentifier[identifier]!
+            )
+            contentViews[identifier] = contentView
+            return contentView
+        }
+    )
+
+    containerView.addSubview(view)
+    NSLayoutConstraint.activate([
+        view.leadingAnchor.constraint(equalTo: containerView.leadingAnchor),
+        view.topAnchor.constraint(equalTo: containerView.topAnchor),
+        view.widthAnchor.constraint(equalToConstant: size.width),
+        view.heightAnchor.constraint(equalToConstant: size.height)
+    ])
+    view.addButtons()
+
+    return ActionsViewFixture(
+        containerView: containerView,
+        view: view,
+        actions: actions,
+        contentViews: contentViews
+    )
+}


### PR DESCRIPTION
Extends SwipeCellKit customization to support the new swipe-action design:
- Adds equal and individual action-width modes
- Adds a configurable activation threshold for opening actions
- Adds transition preparation and interactive-state callbacks
- Adds fill-available-space expansion for the primary action
- Allows custom action content to react to expansion width changes
- Updates the example app with spring reveal and circle-to-pill action content
- Adds unit tests covering the new behaviour